### PR TITLE
transport: implement request helpers

### DIFF
--- a/courier/transport/request.py
+++ b/courier/transport/request.py
@@ -7,7 +7,7 @@ import requests
 from courier.exceptions import HttpError
 
 
-def raise_for_status_with_body(resp: requests.Response) -> None:
+def _raise_for_status_with_body(resp: requests.Response) -> None:
     """
     Raise `HttpError` if the response indicates an HTTP error.
 
@@ -53,7 +53,7 @@ def read_json(resp: requests.Response) -> Any:
     HttpError
         If status indicates error or JSON decoding fails.
     """
-    raise_for_status_with_body(resp)
+    _raise_for_status_with_body(resp)
     try:
         return resp.json()
     except ValueError as e:
@@ -85,5 +85,5 @@ def read_text(resp: requests.Response) -> str:
     HttpError
         If status indicates error.
     """
-    raise_for_status_with_body(resp)
+    _raise_for_status_with_body(resp)
     return resp.text

--- a/tests/unit/transport/test_request.py
+++ b/tests/unit/transport/test_request.py
@@ -3,7 +3,7 @@ import unittest
 import requests
 
 from courier.exceptions import HttpError
-from courier.transport.request import raise_for_status_with_body, read_json
+from courier.transport.request import _raise_for_status_with_body, read_json
 
 
 class _FakeRequest:
@@ -57,7 +57,7 @@ class TestRaiseForStatusWithBody(unittest.TestCase):
         )
 
         with self.assertRaises(HttpError) as ctx:
-            raise_for_status_with_body(resp)
+            _raise_for_status_with_body(resp)
 
         err = ctx.exception
         self.assertEqual(err.method, "GET")
@@ -75,7 +75,7 @@ class TestRaiseForStatusWithBody(unittest.TestCase):
         )
 
         with self.assertRaises(HttpError) as ctx:
-            raise_for_status_with_body(resp)
+            _raise_for_status_with_body(resp)
 
         self.assertEqual(ctx.exception.method, "HTTP")
 


### PR DESCRIPTION
Another PR to make #7 more readable.

This PR adds the request/response helper utilities for the transport layer.

#### Summary
- Ported the request helpers from `refactor_project_structure` (`courier/http/request.py`) into the `refactor` layout.
- Moved them into `courier/transport/request.py`, replacing the existing placeholder.
- The module provides:
  - `raise_for_status_with_body()` raising `HttpError` with response body when available
  - `read_json()` and `read_text()` convenience functions that validate status first

#### Notes
- This PR is stacked on top of the `url` branch and is intended to be merged into `transport` once `url` is merged.