### PR TITLE
[nit] run black for conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ copyright = (
 #
 # The short X.Y version.
 version_full = courier.__version__
-version = '.'.join(version_full.split('.')[:2])
+version = ".".join(version_full.split(".")[:2])
 # The full version, including alpha/beta/rc tags.
 release = version_full
 


### PR DESCRIPTION
I keep running black elsewhere and every time I accidentally change `conf.py` from this module, so I merge it properly to not have this issue anymore