### PR TITLE
refactor tests: strengthen validation message assertions in unit tests

### DIFF
--- a/tests/unit/services/ontodocker/test_compat.py
+++ b/tests/unit/services/ontodocker/test_compat.py
@@ -62,15 +62,15 @@ class TestParseEndpointsResponse(unittest.TestCase):
         self.assertEqual(result, ["http://example.com/path"])
 
     def test_invalid_literal_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "Failed to parse endpoints response"):
             _compat.parse_endpoints_response("not a valid literal", rectify=False)
 
     def test_non_list_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"did not parse to list\[str\]"):
             _compat.parse_endpoints_response("{'a': 1}", rectify=False)
 
     def test_list_of_non_strings_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"did not parse to list\[str\]"):
             _compat.parse_endpoints_response("[1, 2, 3]", rectify=False)
 
 
@@ -91,7 +91,7 @@ class TestExtractDatasetNames(unittest.TestCase):
         self.assertEqual(_compat.extract_dataset_names(endpoints), ["ds1", "ds2"])
 
     def test_unexpected_format_raises_value_error(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "Unexpected SPARQL endpoint format"):
             _compat.extract_dataset_names(["https://example.com/wrong/path"])
 
     def test_trailing_slash_handled(self):

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -136,37 +136,37 @@ class TestHttpClientInit(unittest.TestCase):
 
 class TestHttpClientValidation(unittest.TestCase):
     def test_timeout_must_be_positive(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"timeout must be > 0"):
             _ = HttpClient("example.org", timeout=0)
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"timeout must be > 0"):
             _ = HttpClient("example.org", timeout=-1)
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"both values > 0"):
             _ = HttpClient("example.org", timeout=(1, 0))
 
     def test_timeout_type_is_checked(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, r"length 2"):
             _ = HttpClient("example.org", timeout=(1, 2, 3))
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, r"length 2"):
             _ = HttpClient("example.org", timeout=True)
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, r"length 2"):
             _ = HttpClient("example.org", timeout=False)
 
     def test_timeout_tuple_with_non_numeric_raises_type_error(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, r"numeric values"):
             _ = HttpClient("example.org", timeout=("a", "b"))
 
     def test_default_scheme_is_validated(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"must be one of"):
             _ = HttpClient("example.org", default_scheme="ftp")
 
     def test_empty_default_scheme_raises(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"non-empty string"):
             _ = HttpClient("example.org", default_scheme="")
 
     def test_verify_must_be_bool_or_nonempty_string(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r"empty string"):
             _ = HttpClient("example.org", verify="")
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError, r"bool or a non-empty string"):
             _ = HttpClient("example.org", verify=object())
 
     def test_verify_as_nonempty_string_is_accepted(self):

--- a/tests/unit/test_ontodocker_client.py
+++ b/tests/unit/test_ontodocker_client.py
@@ -188,9 +188,11 @@ class TestDatasetsResource(unittest.TestCase):
         s = _FakeSession()
         c = OntodockerClient("https://example.org", session=s)
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "dataset name must be non-empty"):
             _ = c.datasets.download_turtle("", Path("out.ttl"))
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError, "filename must be a non-empty path"
+        ):
             _ = c.datasets.download_turtle("ds", "   ")
 
     def test_download_turtle_writes_file_when_requested(self):
@@ -209,10 +211,12 @@ class TestDatasetsResource(unittest.TestCase):
         s = _FakeSession()
         c = OntodockerClient("https://example.org", session=s)
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "dataset name must be non-empty"):
             _ = c.datasets.upload_turtlefile("", "x.ttl")
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError, "turtlefile must be a non-empty path"
+        ):
             _ = c.datasets.upload_turtlefile("ds", "")
 
     def test_upload_turtlefile_missing_file_raises_file_not_found(self):
@@ -254,7 +258,7 @@ class TestDatasetsResource(unittest.TestCase):
         s = _FakeSession()
         c = OntodockerClient("https://example.org", session=s)
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "rdflib.Graph instance"):
             _ = c.datasets.upload_graph("ds", object())
 
     def test_upload_graph_propagates_serialize_errors(self):
@@ -312,7 +316,7 @@ class TestSparqlResource(unittest.TestCase):
     def test_endpoint_validates_dataset(self):
         s = _FakeSession()
         c = OntodockerClient("https://example.org", session=s)
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "dataset must be non-empty"):
             _ = c.sparql.endpoint("")
 
     def test_endpoint_builds_url(self):
@@ -327,10 +331,10 @@ class TestSparqlResource(unittest.TestCase):
         s = _FakeSession()
         c = OntodockerClient("https://example.org", session=s)
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "dataset must be non-empty"):
             _ = c.sparql.query_raw("", "SELECT * WHERE {}")
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "query must be non-empty"):
             _ = c.sparql.query_raw("ds", "")
 
     def test_query_raw_uses_get_with_query_param_and_accept_header(self):
@@ -359,22 +363,30 @@ class TestSparqlResource(unittest.TestCase):
         s = _FakeSession()
         c = OntodockerClient("https://example.org", session=s)
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "dataset must be non-empty"):
             _ = c.sparql.query_df("", "SELECT ?a WHERE {}", columns=["a"])
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "query must be non-empty"):
             _ = c.sparql.query_df("ds", "", columns=["a"])
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError, "columns must be a non-empty list of strings"
+        ):
             _ = c.sparql.query_df("ds", "SELECT ?a WHERE {}", columns=[])
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError, "columns must be a non-empty list of strings"
+        ):
             _ = c.sparql.query_df("ds", "SELECT ?a WHERE {}", columns=["a", " "])
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError, "columns must be a non-empty list of strings"
+        ):
             _ = c.sparql.query_df("ds", "SELECT ?a WHERE {}", columns=["a", 1])
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError, "columns must be a non-empty list of strings"
+        ):
             _ = c.sparql.query_df("ds", "SELECT ?a WHERE {}", columns=("a",))
 
     def test_query_df_raises_json_decode_error_on_invalid_json(self):

--- a/tests/unit/transport/test_url.py
+++ b/tests/unit/transport/test_url.py
@@ -62,9 +62,11 @@ class TestNormalizeBaseUrl(unittest.TestCase):
 class TestJoinUrl(unittest.TestCase):
     def test_blank_base_raises(self):
         for base in ["", " ", "\n"]:
-            with self.subTest(base=base):
-                with self.assertRaisesRegex(ValidationError, "non-empty URL"):
-                    join_url(base, segments=["api"])
+            with (
+                self.subTest(base=base),
+                self.assertRaisesRegex(ValidationError, "non-empty URL"),
+            ):
+                join_url(base, segments=["api"])
 
     def test_join_normalizes_slashes(self):
         self.assertEqual(

--- a/tests/unit/transport/test_url.py
+++ b/tests/unit/transport/test_url.py
@@ -63,7 +63,8 @@ class TestJoinUrl(unittest.TestCase):
     def test_blank_base_raises(self):
         for base in ["", " ", "\n"]:
             with self.subTest(base=base):
-                self.assertRaises(ValidationError, join_url, base, segments=["api"])
+                with self.assertRaisesRegex(ValidationError, "non-empty URL"):
+                    join_url(base, segments=["api"])
 
     def test_join_normalizes_slashes(self):
         self.assertEqual(


### PR DESCRIPTION
After [this comment](https://github.com/pyiron/courier/pull/43#issuecomment-4238565208) from @samwaseda , I realized that there were more tests not actually testing the reason an exception is raised but only the corresponding error type (e.g. an `InvalidAddressError` is raised, but it's not clear if the address is invalid because it is an empty string or because it is malformatted).
I think it is overall a good idea to strengthen testing regarding regression protection.

In this PR I
- tightened unit tests around validation and parsing failures by asserting message content where the message distinguishes meaningful branches.
- added message checks for `join_url` blank-base validation and for `HttpClient` input validation covering `timeout`, `default_scheme`, and `verify`.
- added message checks for Ontodocker compatibility helpers so parse failures and unexpected endpoint formats are verified more precisely.
- added selected message checks for Ontodocker dataset/SPARQL validation paths, including invalid dataset names, empty turtlefile paths, invalid graph types, empty queries, and invalid columns.