### PR TITLE
refactor/tests: add explicit assertion messages to unit tests

### DIFF
--- a/tests/unit/services/ontodocker/test_compat.py
+++ b/tests/unit/services/ontodocker/test_compat.py
@@ -125,7 +125,11 @@ class TestMakeDataframe(unittest.TestCase):
             }
         }
         df = _compat.make_dataframe(result, ["x", "y"])
-        self.assertEqual(list(df.columns), ["x", "y"])
+        self.assertEqual(
+            list(df.columns),
+            ["x", "y"],
+            msg="make_dataframe() should preserve the requested column order",
+        )
 
     def test_empty_bindings(self):
         result = self._make_result(["a", "b"], [])

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -191,7 +191,11 @@ class TestHttpClientRequest(unittest.TestCase):
             stream=True,
         )
 
-        self.assertEqual(len(s.calls), 1)
+        self.assertEqual(
+            len(s.calls),
+            1,
+            msg="request() should delegate to session.request() exactly once",
+        )
         call = s.calls[0]
         self.assertEqual(call["method"], "POST")
         self.assertEqual(call["url"], "https://example.org/api")

--- a/tests/unit/test_ontodocker_client.py
+++ b/tests/unit/test_ontodocker_client.py
@@ -447,7 +447,10 @@ class TestSparqlResource(unittest.TestCase):
         self.assertIsInstance(df, pd.DataFrame)
         self.assertEqual(list(df.columns), ["a", "b"])
         self.assertEqual(df.iloc[0]["a"], "1")
-        self.assertTrue(pd.isna(df.iloc[0]["b"]))
+        self.assertTrue(
+            pd.isna(df.iloc[0]["b"]),
+            msg="missing SPARQL bindings should map to None/NaN in the dataframe",
+        )
         self.assertTrue(pd.isna(df.iloc[1]["a"]))
         self.assertEqual(df.iloc[1]["b"], "2")
         self.assertEqual(

--- a/tests/unit/test_ontodocker_client.py
+++ b/tests/unit/test_ontodocker_client.py
@@ -488,7 +488,11 @@ class TestSparqlResource(unittest.TestCase):
             {"Accept": "application/sparql-results+json"},
         )
         # token is handled by HttpClient via session headers, not per-request
-        self.assertEqual(s.headers.get("Authorization"), "Bearer abc")
+        self.assertEqual(
+            s.headers.get("Authorization"),
+            "Bearer abc",
+            msg="token-based auth should be stored on session headers for SPARQL requests",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/transport/test_request.py
+++ b/tests/unit/transport/test_request.py
@@ -103,7 +103,10 @@ class TestReadJson(unittest.TestCase):
             _ = read_json(resp)
 
         self.assertTrue(resp.raise_for_status_called)
-        self.assertFalse(resp.json_called)
+        self.assertFalse(
+            resp.json_called,
+            msg="read_json() should not attempt JSON decoding after HTTP status handling fails",
+        )
 
         err = ctx.exception
         self.assertIsInstance(err.__cause__, requests.HTTPError)


### PR DESCRIPTION
Add explicit assertion messages to a small set of unit tests so CI failures point directly to the behavior each check is guarding.

- update `tests/unit/transport/test_request.py` to explain that `read_json()` must stop before JSON decoding when HTTP status handling fails
- update `tests/unit/test_http_client.py` to make the `HttpClient.request()` delegation check self-describing
- update `tests/unit/test_ontodocker_client.py` to clarify missing SPARQL binding handling and session-level token authentication expectations
- update `tests/unit/services/ontodocker/test_compat.py` to spell out the expected dataframe column-order behavior