### PR TITLE
feature/http-notebooks: add example notebook for HttpClient

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.10
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.1.0
     secrets: inherit

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-4.0.10
+    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-4.1.0
     secrets: inherit

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-4.0.10
+    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-4.1.0
     secrets: inherit

--- a/.github/workflows/pr-target-opened.yml
+++ b/.github/workflows/pr-target-opened.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-4.0.10
+    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-4.1.0
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@notebook-envvars
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.1.0
     secrets: inherit
     with:
       do-coveralls: false

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -24,7 +24,7 @@ jobs:
       alternate-tests-env-files: .ci_support/lower-bounds.yml
       alternate-tests-python-version: '3.11'
       alternate-tests-dir: tests/unit
-      # load sectrets as environment variables
+      # load secrets as environment variables
       notebooks-secret-env-map: |
         HTTPCLIENT_TOKEN=ONTODOCKERCLIENT_TOKEN
         HTTPCLIENT_ADDRESS=ONTODOCKERCLIENT_ADDRESS

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.10
+    uses: pyiron/actions/.github/workflows/push-pull.yml@notebook-envvars
     secrets: inherit
     with:
       do-coveralls: false
@@ -24,3 +24,7 @@ jobs:
       alternate-tests-env-files: .ci_support/lower-bounds.yml
       alternate-tests-python-version: '3.11'
       alternate-tests-dir: tests/unit
+      # load sectrets as environment variables
+      notebooks-secret-env-map: |
+        HTTPCLIENT_TOKEN
+        HTTPKLIEN_ADDRESS

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -26,5 +26,5 @@ jobs:
       alternate-tests-dir: tests/unit
       # load sectrets as environment variables
       notebooks-secret-env-map: |
-        HTTPCLIENT_TOKEN
-        HTTPCLIENT_ADDRESS
+        HTTPCLIENT_TOKEN=ONTODOCKERCLIENT_TOKEN
+        HTTPCLIENT_ADDRESS=ONTODOCKERCLIENT_ADDRESS

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -27,4 +27,4 @@ jobs:
       # load sectrets as environment variables
       notebooks-secret-env-map: |
         HTTPCLIENT_TOKEN
-        HTTPKLIEN_ADDRESS
+        HTTPCLIENT_ADDRESS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   hatch-release:
-    uses: pyiron/actions/.github/workflows/hatch-release.yml@actions-4.0.10
+    uses: pyiron/actions/.github/workflows/hatch-release.yml@actions-4.1.0
     secrets: inherit
     with:
       semantic-upper-bound: 'minor'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.10
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.1.0
     secrets: inherit

--- a/notebooks/HttpClient.ipynb
+++ b/notebooks/HttpClient.ipynb
@@ -5,11 +5,11 @@
    "id": "d604f6d6-9c98-4bc7-8fdb-d2d840d3ba69",
    "metadata": {},
    "source": [
-    "# HttpClient (internal)\n",
+    "# HttpClient\n",
     "\n",
-    "`courier.base_client.HttpClient` is a small internal building block used by service clients whose API builds on top of http requests (e.g. `OntodockerClient`).\n",
+    "`courier.base_client.HttpClient` is a building block used by service clients whose API builds on top of http requests (e.g. `OntodockerClient`). I can also be used directly for services where no proper client is implemented yet.\n",
     "\n",
-    "This notebook shows the minimal usage of its public `request(...)` escape hatch, allowing raw requests within `courier`. This can be used, e.g., in the case a specific servie exposes endpoints which are not wrapped by a client implementation available inside `courier`."
+    "This notebook shows the minimal usage of its public `request(...)` escape hatch, allowing raw requests within `courier`. This can be used, e.g., in the case a specific service exposes endpoints which are not wrapped by a client implementation available inside `courier`."
    ]
   },
   {
@@ -18,12 +18,11 @@
    "metadata": {},
    "source": [
     "## Setup\n",
-    "To execute this notebook, your shell need to source a file, where 2 environment variable are assigned:\n",
+    "To execute this notebook, your shell needs to export two environment variables:\n",
     "```\n",
-    "export HTTPCLIENT_TOKEN=\"<token of your http service>\"\n",
-    "export HTTPCLIENT_ADDRESS=\"<address of your http service's endpoint>\"\n",
+    "export HTTPCLIENT_ADRESS=\"<address of your http service's endpoint>\"\n",
     "```\n",
-    "Then, launch jupyter from this shell."
+    "Then, launch Jupyter from this shell."
    ]
   },
   {
@@ -80,16 +79,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "5cf6202c-a1e1-4663-99ac-07dec5ff5a5d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "headers = {\"Authorization\": f\"Bearer {token}\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
    "id": "0f7595eb-4d63-4fc3-aa05-56c44624d2e2",
    "metadata": {},
    "outputs": [
@@ -99,19 +88,19 @@
        "200"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "resp = client.request(method=\"GET\", url=client.base_url+\"/api/v1/endpoints\", headers=headers)\n",
+    "resp = client.request(method=\"GET\", url=client.base_url+\"/api/v1/endpoints\")\n",
     "resp.status_code"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "8b18df83-e769-4f6b-a626-01bfd13a704e",
    "metadata": {},
    "outputs": [
@@ -121,7 +110,7 @@
        "'[\"http://ontodocker.pmds-mpcdf-2.pyiron.com:None/api/jena/pmdco2_tto_example/sparql\"]'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/HttpClient.ipynb
+++ b/notebooks/HttpClient.ipynb
@@ -21,7 +21,7 @@
     "To execute this notebook, your shell need to source a file, where 2 environment variable are assigned:\n",
     "```\n",
     "export HTTPCLIENT_TOKEN=\"<token of your http service>\"\n",
-    "export HTTPCLIENT_ADRESS=\"<address of your http service's endpoint>\"\n",
+    "export HTTPCLIENT_ADDRESS=\"<address of your http service's endpoint>\"\n",
     "```\n",
     "Then, launch jupyter from this shell."
    ]

--- a/notebooks/HttpClient.ipynb
+++ b/notebooks/HttpClient.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d604f6d6-9c98-4bc7-8fdb-d2d840d3ba69",
+   "metadata": {},
+   "source": [
+    "# HttpClient (internal)\n",
+    "\n",
+    "`courier.base_client.HttpClient` is a small internal building block used by service clients whose API builds on top of http requests (e.g. `OntodockerClient`).\n",
+    "\n",
+    "This notebook shows the minimal usage of its public `request(...)` escape hatch, allowing raw requests within `courier`. This can be used, e.g., in the case a specific servie exposes endpoints which are not wrapped by a client implementation available inside `courier`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e38f41e-d743-4708-b534-6567c299a4d6",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "To execute this notebook, your shell need to source a file, where 2 environment variable are assigned:\n",
+    "```\n",
+    "export HTTPCLIENT_TOKEN=\"<token of your http service>\"\n",
+    "export HTTPCLIENT_ADRESS=\"<address of your http service's endpoint>\"\n",
+    "```\n",
+    "Then, launch jupyter from this shell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8e352fb0-7bec-4c16-9829-960b69718580",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os \n",
+    "\n",
+    "def require_env(name: str) -> str:\n",
+    "    value = os.getenv(name)\n",
+    "    if value is None or not value.strip():\n",
+    "        raise RuntimeError(f\"Required environment variable {name} is not set.\")\n",
+    "    return value.strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f522c60a-3da3-4fd7-b7c1-a68753fa7216",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token = require_env(\"HTTPCLIENT_TOKEN\") \n",
+    "address = require_env(\"HTTPCLIENT_ADDRESS\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0d16f0ff-511e-417f-b66a-3ecf9ed85cf6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://ontodocker.pmds-mpcdf-2.pyiron.com'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from courier import HttpClient\n",
+    "\n",
+    "client = HttpClient(address=address, token=token)\n",
+    "client.base_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5cf6202c-a1e1-4663-99ac-07dec5ff5a5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "headers = {\"Authorization\": f\"Bearer {token}\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0f7595eb-4d63-4fc3-aa05-56c44624d2e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "200"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resp = client.request(method=\"GET\", url=client.base_url+\"/api/v1/endpoints\", headers=headers)\n",
+    "resp.status_code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8b18df83-e769-4f6b-a626-01bfd13a704e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'[\"http://ontodocker.pmds-mpcdf-2.pyiron.com:None/api/jena/pmdco2_tto_example/sparql\"]'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resp.text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d22b6eb-819d-44a6-9e6f-205530a29a07",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The now added notebook under `notebooks/HttpClient.ipynb` illustrates the basic usage of `courier.HttpClient`.