### PR TITLE
Make import statements leaner in ZenodoClient.ipynb and remove the artifact after the run

### DIFF
--- a/notebooks/ZenodoClient.ipynb
+++ b/notebooks/ZenodoClient.ipynb
@@ -552,7 +552,7 @@
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-pyiron-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/ZenodoClient.ipynb
+++ b/notebooks/ZenodoClient.ipynb
@@ -35,12 +35,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "from datetime import date\n",
     "from pathlib import Path\n",
     "\n",
     "\n",
     "def require_env(name: str) -> str:\n",
+    "    import os\n",
     "    value = os.getenv(name)\n",
     "    if value is None or not value.strip():\n",
     "        raise RuntimeError(f\"Required environment variable {name} is not set.\")\n",
@@ -70,14 +70,10 @@
    ],
    "source": [
     "from courier import ZenodoClient\n",
-    "from courier.exceptions import ValidationError\n",
     "from courier.services.zenodo import (\n",
-    "    CommunityRef,\n",
     "    Contributor,\n",
     "    Creator,\n",
-    "    GrantRef,\n",
     "    RelatedIdentifier,\n",
-    "    ZenodoApiError,\n",
     "    ZenodoMetadata,\n",
     ")\n",
     "\n",
@@ -162,7 +158,7 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'software',\n",
-       " 'publication_date': '2026-04-30',\n",
+       " 'publication_date': '2026-05-12',\n",
        " 'title': 'courier Zenodo sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'Small demonstration upload created with courier.',\n",
@@ -192,7 +188,7 @@
      "data": {
       "text/plain": [
        "{'metadata': {'upload_type': 'software',\n",
-       "  'publication_date': '2026-04-30',\n",
+       "  'publication_date': '2026-05-12',\n",
        "  'title': 'courier Zenodo sandbox demo',\n",
        "  'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        "  'description': 'Small demonstration upload created with courier.',\n",
@@ -231,7 +227,7 @@
     {
      "data": {
       "text/plain": [
-       "494685"
+       "498490"
       ]
      },
      "execution_count": 7,
@@ -275,7 +271,7 @@
     {
      "data": {
       "text/plain": [
-       "'https://sandbox.zenodo.org/deposit/494685'"
+       "'https://sandbox.zenodo.org/deposit/498490'"
       ]
      },
      "execution_count": 9,
@@ -308,7 +304,7 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'software',\n",
-       " 'publication_date': '2026-04-30',\n",
+       " 'publication_date': '2026-05-12',\n",
        " 'title': 'courier Zenodo sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'Small demonstration upload created with courier.',\n",
@@ -353,6 +349,7 @@
     ")\n",
     "\n",
     "# Only use communities/grants that are valid in your sandbox account.\n",
+    "# from courier.services.zenodo import CommunityRef, GrantRef\n",
     "# enriched_metadata.communities.append(CommunityRef(identifier=\"your-sandbox-community\"))\n",
     "# enriched_metadata.grants.append(GrantRef(id=\"10.13039/501100000000::12345\"))\n",
     "\n",
@@ -361,12 +358,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "e6fc2c28",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Run this only after inspecting enriched_metadata.to_api_dict().\n",
+    "# from courier.services.zenodo import ZenodoApiError\n",
     "# try:\n",
     "#     draft = client.depositions.set_metadata(draft, enriched_metadata)\n",
     "# except ZenodoApiError as exc:\n",
@@ -391,10 +389,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "221de996",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Doe J. (2026). Example reference for a sandbox upload. DOI:10.0000/example',\n",
+       " 'Smith A. (2025). Another reference. Example Journal.']"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "raw_metadata = metadata.to_api_dict()\n",
     "raw_metadata[\"references\"] = [\n",
@@ -408,10 +418,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "2fee410e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'upload_type': 'dataset',\n",
+       " 'publication_date': '2026-05-12',\n",
+       " 'title': 'courier raw metadata sandbox demo',\n",
+       " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
+       " 'description': 'A draft using a raw metadata mapping.',\n",
+       " 'access_right': 'open',\n",
+       " 'license': 'cc-by-4.0',\n",
+       " 'references': ['Doe J. (2026). Raw metadata reference. DOI:10.0000/raw-example']}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "raw_only_metadata = {\n",
     "    \"upload_type\": \"dataset\",\n",
@@ -440,10 +468,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "7055a1ce",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('courier Zenodo sandbox demo', 'Doe, Jane')"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "round_tripped = ZenodoMetadata.from_dict({\"metadata\": raw_metadata})\n",
     "round_tripped.title, round_tripped.creators[0].name"
@@ -461,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "2bb87bdd",
    "metadata": {},
    "outputs": [],
@@ -482,13 +521,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 16,
    "id": "64209aca",
    "metadata": {},
    "outputs": [],
    "source": [
     "client.depositions.delete(draft)\n",
-    "# artifact.unlink(missing_ok=True)"
+    "artifact.unlink(missing_ok=True)"
    ]
   },
   {
@@ -511,9 +550,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:pyiron]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-pyiron-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -525,7 +564,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/ZenodoClient.ipynb
+++ b/notebooks/ZenodoClient.ipynb
@@ -550,7 +550,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:pyiron]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "conda-env-pyiron-py"
   },


### PR DESCRIPTION
This pull request updates the `notebooks/ZenodoClient.ipynb` notebook to improve code clarity, update sample data, and ensure outputs reflect the latest test runs. The main changes include moving imports inside functions for better encapsulation, updating example metadata and outputs, and cleaning up unused imports. The notebook kernel metadata has also been updated.

**Code and Import Organization:**
* Moved the `os` import inside the `require_env` function to reduce global namespace pollution.
* Removed unused imports such as `ValidationError`, `CommunityRef`, `GrantRef`, and `ZenodoApiError` from the top of the notebook; added them as commented imports near relevant code cells for clarity. [[1]](diffhunk://#diff-6f2547d61da244618a0393530bda6d2fc5a64ef82d280e37ec6409de0ead250aL73-L80) [[2]](diffhunk://#diff-6f2547d61da244618a0393530bda6d2fc5a64ef82d280e37ec6409de0ead250aR352) [[3]](diffhunk://#diff-6f2547d61da244618a0393530bda6d2fc5a64ef82d280e37ec6409de0ead250aL364-R367)

**Minor Code Cleanups:**
* Uncommented the `artifact.unlink(missing_ok=True)` line to ensure artifacts are cleaned up after deletion.