### PR TITLE
Set 'notebooks' as working directory for execution and adjust paths

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.1.0
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.2.0
     secrets: inherit
     with:
       do-coveralls: false
@@ -31,4 +31,5 @@ jobs:
         ONTODOCKER_TOKEN=ONTODOCKERCLIENT_TOKEN
         ONTODOCKER_ADDRESS=ONTODOCKERCLIENT_ADDRESS
         ZENODO_SANDBOX_TOKEN=ZENODO_SANDBOX_TOKEN
+      notebooks-working-directory: notebooks
         

--- a/notebooks/OntodockerClient.ipynb
+++ b/notebooks/OntodockerClient.ipynb
@@ -252,7 +252,7 @@
     }
    ],
    "source": [
-    "turtle_path = Path(\"notebooks/resources/test_dataset.ttl\")\n",
+    "turtle_path = Path(\"resources/test_dataset.ttl\")\n",
     "assert turtle_path.exists(), turtle_path\n",
     "turtle_path"
    ]


### PR DESCRIPTION
This PR is supposed to validate the new notebook-cwd feature introduced in pyiron/actions via [this PR](https://github.com/pyiron/actions/pull/172).

With a successful validation, this PR will also directly integrate the usage of the new feature.

The advantage afterwards is that a user cloning this repo, running jupyter and opening a notebook from `notebooks` can right away execute notebooks end-to-end, even if files are referenced (like, e.g. in `OntodockClient.ipynb`) while also letting the CI execute them successfully. Before, there was a mismatch: CI runners had the repo root as working directory for notebook execution, a local user will typically have `notebooks/` as the kernels working directory.