### PR TITLE
Unify Zenodo file uploads

### DIFF
--- a/courier/services/zenodo/files.py
+++ b/courier/services/zenodo/files.py
@@ -140,7 +140,7 @@ def _deposition_id(deposition: int | str | DepositionInfo) -> int | str:
 
 
 def _upload_paths(paths: UploadPaths) -> list[Path]:
-    if isinstance(paths, str | Path):
+    if isinstance(paths, (str, Path)):
         return [Path(paths)]
     return [Path(path) for path in paths]
 

--- a/courier/services/zenodo/files.py
+++ b/courier/services/zenodo/files.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from courier.exceptions import ValidationError
 from courier.services.zenodo._response import read_zenodo_json, read_zenodo_text
@@ -19,6 +19,10 @@ from courier.services.zenodo.models import DepositionInfo, UploadedFileInfo
 if TYPE_CHECKING:
     from courier.services.zenodo.client import ZenodoClient
 
+UploadPath: TypeAlias = str | Path
+UploadPaths: TypeAlias = UploadPath | Sequence[UploadPath]
+UploadedFiles: TypeAlias = list[UploadedFileInfo]
+
 
 @dataclass
 class FilesResource:
@@ -26,7 +30,7 @@ class FilesResource:
 
     client: ZenodoClient
 
-    def list(self, deposition: int | str | DepositionInfo) -> list[UploadedFileInfo]:
+    def list(self, deposition: int | str | DepositionInfo) -> UploadedFiles:
         """List files attached to a deposition."""
         url = deposition_files_url(self.client.base_url, _deposition_id(deposition))
         payload = read_zenodo_json(self.client.request("GET", url))
@@ -37,14 +41,14 @@ class FilesResource:
     def upload(
         self,
         deposition: int | str | DepositionInfo,
-        paths: str | Path | Sequence[str | Path],
+        paths: UploadPaths,
         *,
         filename: str | None = None,
         content_type: str | None = None,
-    ) -> list[UploadedFileInfo]:
+    ) -> UploadedFiles:
         """Upload one or more files through the deposition bucket link."""
-        paths = _upload_paths(paths)
-        single_file = len(paths) == 1
+        upload_paths = _upload_paths(paths)
+        single_file = len(upload_paths) == 1
         if not single_file:
             if filename is not None:
                 raise ValidationError(
@@ -54,11 +58,11 @@ class FilesResource:
                 raise ValidationError(
                     "content_type is only supported for single-file uploads"
                 )
-        if not paths:
+        if not upload_paths:
             return []
         filenames = [
             _upload_filename(path, filename=filename if single_file else None)
-            for path in paths
+            for path in upload_paths
         ]
 
         deposition_info = self._ensure_deposition(deposition)
@@ -73,7 +77,7 @@ class FilesResource:
                 filename=file_name,
                 content_type=content_type,
             )
-            for path, file_name in zip(paths, filenames, strict=True)
+            for path, file_name in zip(upload_paths, filenames, strict=True)
         ]
 
     def _upload_one(
@@ -135,7 +139,7 @@ def _deposition_id(deposition: int | str | DepositionInfo) -> int | str:
     return deposition
 
 
-def _upload_paths(paths: str | Path | Sequence[str | Path]) -> list[Path]:
+def _upload_paths(paths: UploadPaths) -> list[Path]:
     if isinstance(paths, str | Path):
         return [Path(paths)]
     return [Path(path) for path in paths]

--- a/courier/services/zenodo/files.py
+++ b/courier/services/zenodo/files.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from builtins import list as builtin_list
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,38 +37,62 @@ class FilesResource:
     def upload(
         self,
         deposition: int | str | DepositionInfo,
-        path: str | Path,
+        paths: str | Path | Sequence[str | Path],
         *,
         filename: str | None = None,
         content_type: str | None = None,
-    ) -> UploadedFileInfo:
-        """Upload a file through the deposition bucket link."""
-        path = Path(path)
-        filename = (filename or path.name).strip()
-        if not filename:
-            raise ValidationError("filename must be non-empty")
+    ) -> list[UploadedFileInfo]:
+        """Upload one or more files through the deposition bucket link."""
+        paths = _upload_paths(paths)
+        single_file = len(paths) == 1
+        if not single_file:
+            if filename is not None:
+                raise ValidationError(
+                    "filename is only supported for single-file uploads"
+                )
+            if content_type is not None:
+                raise ValidationError(
+                    "content_type is only supported for single-file uploads"
+                )
+        if not paths:
+            return []
+        filenames = [
+            _upload_filename(path, filename=filename if single_file else None)
+            for path in paths
+        ]
 
         deposition_info = self._ensure_deposition(deposition)
-        if not deposition_info.links.bucket:
+        bucket_url = deposition_info.links.bucket
+        if not bucket_url:
             raise ValidationError("deposition does not include a bucket upload link")
 
+        return [
+            self._upload_one(
+                bucket_url,
+                path,
+                filename=file_name,
+                content_type=content_type,
+            )
+            for path, file_name in zip(paths, filenames, strict=True)
+        ]
+
+    def _upload_one(
+        self,
+        bucket_url: str,
+        path: Path,
+        *,
+        filename: str,
+        content_type: str | None = None,
+    ) -> UploadedFileInfo:
         headers = {"Content-Type": content_type} if content_type else None
         with path.open("rb") as file:
             resp = self.client.request(
                 "PUT",
-                bucket_file_url(deposition_info.links.bucket, filename),
+                bucket_file_url(bucket_url, filename),
                 data=file,
                 headers=headers,
             )
         return UploadedFileInfo.from_dict(read_zenodo_json(resp))
-
-    def upload_many(
-        self,
-        deposition: int | str | DepositionInfo,
-        paths: Sequence[str | Path],
-    ) -> builtin_list[UploadedFileInfo]:
-        """Upload multiple files to a deposition."""
-        return [self.upload(deposition, path) for path in paths]
 
     def rename(
         self,
@@ -110,3 +133,16 @@ def _deposition_id(deposition: int | str | DepositionInfo) -> int | str:
     if isinstance(deposition, DepositionInfo):
         return deposition.id
     return deposition
+
+
+def _upload_paths(paths: str | Path | Sequence[str | Path]) -> list[Path]:
+    if isinstance(paths, str | Path):
+        return [Path(paths)]
+    return [Path(path) for path in paths]
+
+
+def _upload_filename(path: Path, *, filename: str | None = None) -> str:
+    file_name = (filename or path.name).strip()
+    if not file_name:
+        raise ValidationError("filename must be non-empty")
+    return file_name

--- a/notebooks/ZenodoClient.ipynb
+++ b/notebooks/ZenodoClient.ipynb
@@ -249,7 +249,7 @@
     {
      "data": {
       "text/plain": [
-       "('demo_artifact.txt', 42)"
+       "[('demo_artifact.txt', 42)]"
       ]
      },
      "execution_count": 8,
@@ -259,7 +259,7 @@
    ],
    "source": [
     "uploaded = client.files.upload(draft, artifact)\n",
-    "uploaded.filename, uploaded.size"
+    "[(file.filename, file.size) for file in uploaded]"
    ]
   },
   {

--- a/notebooks/ZenodoClient.ipynb
+++ b/notebooks/ZenodoClient.ipynb
@@ -228,7 +228,7 @@
     {
      "data": {
       "text/plain": [
-       "499007"
+       "499013"
       ]
      },
      "execution_count": 7,
@@ -272,7 +272,7 @@
     {
      "data": {
       "text/plain": [
-       "'https://sandbox.zenodo.org/deposit/499007'"
+       "'https://sandbox.zenodo.org/deposit/499013'"
       ]
      },
      "execution_count": 9,

--- a/notebooks/ZenodoClient.ipynb
+++ b/notebooks/ZenodoClient.ipynb
@@ -41,6 +41,7 @@
     "\n",
     "def require_env(name: str) -> str:\n",
     "    import os\n",
+    "\n",
     "    value = os.getenv(name)\n",
     "    if value is None or not value.strip():\n",
     "        raise RuntimeError(f\"Required environment variable {name} is not set.\")\n",

--- a/notebooks/ZenodoClient.ipynb
+++ b/notebooks/ZenodoClient.ipynb
@@ -158,7 +158,7 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'software',\n",
-       " 'publication_date': '2026-05-12',\n",
+       " 'publication_date': '2026-05-13',\n",
        " 'title': 'courier Zenodo sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'Small demonstration upload created with courier.',\n",
@@ -188,7 +188,7 @@
      "data": {
       "text/plain": [
        "{'metadata': {'upload_type': 'software',\n",
-       "  'publication_date': '2026-05-12',\n",
+       "  'publication_date': '2026-05-13',\n",
        "  'title': 'courier Zenodo sandbox demo',\n",
        "  'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        "  'description': 'Small demonstration upload created with courier.',\n",
@@ -227,7 +227,7 @@
     {
      "data": {
       "text/plain": [
-       "498490"
+       "499007"
       ]
      },
      "execution_count": 7,
@@ -271,7 +271,7 @@
     {
      "data": {
       "text/plain": [
-       "'https://sandbox.zenodo.org/deposit/498490'"
+       "'https://sandbox.zenodo.org/deposit/499007'"
       ]
      },
      "execution_count": 9,
@@ -304,7 +304,7 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'software',\n",
-       " 'publication_date': '2026-05-12',\n",
+       " 'publication_date': '2026-05-13',\n",
        " 'title': 'courier Zenodo sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'Small demonstration upload created with courier.',\n",
@@ -426,7 +426,7 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'dataset',\n",
-       " 'publication_date': '2026-05-12',\n",
+       " 'publication_date': '2026-05-13',\n",
        " 'title': 'courier raw metadata sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'A draft using a raw metadata mapping.',\n",
@@ -564,7 +564,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.3"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/tests/unit/services/zenodo/test_files.py
+++ b/tests/unit/services/zenodo/test_files.py
@@ -80,8 +80,9 @@ class TestFilesResource(unittest.TestCase):
             _ = path.write_bytes(b"payload")
             uploaded = c.files.upload(deposition, path, content_type="application/zip")
 
-        self.assertEqual(uploaded.filename, "artifact.zip")
-        self.assertEqual(uploaded.size, 123)
+        self.assertEqual(len(uploaded), 1)
+        self.assertEqual(uploaded[0].filename, "artifact.zip")
+        self.assertEqual(uploaded[0].size, 123)
         self.assertEqual(session.calls[0]["method"], "PUT")
         self.assertEqual(
             session.calls[0]["url"],
@@ -145,7 +146,7 @@ class TestFilesResource(unittest.TestCase):
         self.assertEqual(session.calls[0]["method"], "GET")
         self.assertEqual(session.calls[1]["method"], "PUT")
 
-    def test_upload_many_uploads_each_path(self):
+    def test_upload_uploads_each_path(self):
         session = FakeSession(
             [
                 FakeResponse(json_value={"key": "one.txt", "size": 1}),
@@ -160,10 +161,34 @@ class TestFilesResource(unittest.TestCase):
             second = Path(tmp) / "two.txt"
             _ = first.write_text("one")
             _ = second.write_text("two")
-            uploaded = c.files.upload_many(deposition, [first, second])
+            uploaded = c.files.upload(deposition, [first, second])
 
         self.assertEqual([file.filename for file in uploaded], ["one.txt", "two.txt"])
         self.assertEqual([call["method"] for call in session.calls], ["PUT", "PUT"])
+
+    def test_upload_rejects_filename_for_multiple_paths(self):
+        session = FakeSession()
+        c = ZenodoClient(session=cast(Any, session))
+
+        with TemporaryDirectory() as tmp:
+            first = Path(tmp) / "one.txt"
+            second = Path(tmp) / "two.txt"
+            with self.assertRaisesRegex(ValidationError, "filename"):
+                c.files.upload(42, [first, second], filename="artifact.txt")
+
+        self.assertEqual(session.calls, [])
+
+    def test_upload_rejects_content_type_for_multiple_paths(self):
+        session = FakeSession()
+        c = ZenodoClient(session=cast(Any, session))
+
+        with TemporaryDirectory() as tmp:
+            first = Path(tmp) / "one.txt"
+            second = Path(tmp) / "two.txt"
+            with self.assertRaisesRegex(ValidationError, "content_type"):
+                c.files.upload(42, [first, second], content_type="text/plain")
+
+        self.assertEqual(session.calls, [])
 
     def test_rename_uses_file_endpoint(self):
         session = FakeSession(

--- a/tests/unit/services/zenodo/test_files.py
+++ b/tests/unit/services/zenodo/test_files.py
@@ -166,6 +166,15 @@ class TestFilesResource(unittest.TestCase):
         self.assertEqual([file.filename for file in uploaded], ["one.txt", "two.txt"])
         self.assertEqual([call["method"] for call in session.calls], ["PUT", "PUT"])
 
+    def test_upload_accepts_empty_path_sequence(self):
+        session = FakeSession()
+        c = ZenodoClient(session=cast(Any, session))
+
+        uploaded = c.files.upload(42, [])
+
+        self.assertEqual(uploaded, [])
+        self.assertEqual(session.calls, [])
+
     def test_upload_rejects_filename_for_multiple_paths(self):
         session = FakeSession()
         c = ZenodoClient(session=cast(Any, session))


### PR DESCRIPTION
Refactors Zenodo file upload handling so `client.files.upload()` accepts either a single `str | Path` or a sequence of paths and consistently returns a list of uploaded file records. This removes the separate `upload_many()` API and updates the notebook example to match the new return type.

# PR summary:
- `upload()` now handles one or many files.
- Return type is always `list[UploadedFileInfo]`.
- Multi-file uploads reject single-file-only options like `filename` and `content_type`.
- Tests and notebook example updated.