### PR TITLE
Remove unused libraries from OntodockerClient.ipynb

### DIFF
--- a/notebooks/OntodockerClient.ipynb
+++ b/notebooks/OntodockerClient.ipynb
@@ -70,7 +70,6 @@
    ],
    "source": [
     "from courier import OntodockerClient\n",
-    "from courier.exceptions import HttpError, ValidationError\n",
     "\n",
     "client = OntodockerClient(address=address, token=token)\n",
     "client.base_url"


### PR DESCRIPTION
This pull request makes a minor update to the `notebooks/OntodockerClient.ipynb` notebook by removing an unused import statement. This helps clean up the code and avoid unnecessary dependencies. 

* Removed the import of `HttpError` and `ValidationError` from `courier.exceptions`, as these exceptions are not used in the notebook.