### PR TITLE
Update notebook: deletion only if deposition is not published

### DIFF
--- a/notebooks/ZenodoClient.ipynb
+++ b/notebooks/ZenodoClient.ipynb
@@ -155,7 +155,7 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'software',\n",
-       " 'publication_date': '2026-05-13',\n",
+       " 'publication_date': '2026-05-19',\n",
        " 'title': 'courier Zenodo sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'Small demonstration upload created with courier.',\n",
@@ -185,7 +185,7 @@
      "data": {
       "text/plain": [
        "{'metadata': {'upload_type': 'software',\n",
-       "  'publication_date': '2026-05-13',\n",
+       "  'publication_date': '2026-05-19',\n",
        "  'title': 'courier Zenodo sandbox demo',\n",
        "  'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        "  'description': 'Small demonstration upload created with courier.',\n",
@@ -224,7 +224,7 @@
     {
      "data": {
       "text/plain": [
-       "499013"
+       "502048"
       ]
      },
      "execution_count": 7,
@@ -268,7 +268,7 @@
     {
      "data": {
       "text/plain": [
-       "'https://sandbox.zenodo.org/deposit/499013'"
+       "'https://sandbox.zenodo.org/deposit/502048'"
       ]
      },
      "execution_count": 9,
@@ -301,7 +301,7 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'software',\n",
-       " 'publication_date': '2026-05-13',\n",
+       " 'publication_date': '2026-05-19',\n",
        " 'title': 'courier Zenodo sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'Small demonstration upload created with courier.',\n",
@@ -423,7 +423,6 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'dataset',\n",
-       " 'publication_date': '2026-05-13',\n",
        " 'title': 'courier raw metadata sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'A draft using a raw metadata mapping.',\n",
@@ -501,8 +500,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# published = client.depositions.publish(draft)\n",
-    "# published.links.html"
+    "published = None\n",
+    "#published = client.depositions.publish(draft)\n",
+    "#published.links.html"
    ]
   },
   {
@@ -522,8 +522,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.depositions.delete(draft)\n",
-    "artifact.unlink(missing_ok=True)"
+    "if published is None:\n",
+    "    client.depositions.delete(draft)\n",
+    "    artifact.unlink(missing_ok=True)\n",
+    "else:\n",
+    "    print(\"Deletion of published depositions is not supported by Zenodo's API.\")"
    ]
   },
   {


### PR DESCRIPTION
This pull request makes minor updates to the `notebooks/ZenodoClient.ipynb` notebook, primarily to improve the handling of published depositions.

Improved handling of published depositions:
* Added logic to check if a deposition has been published before attempting deletion, printing a message if deletion is not supported by Zenodo's API. [[1]](diffhunk://#diff-6f2547d61da244618a0393530bda6d2fc5a64ef82d280e37ec6409de0ead250aR503) [[2]](diffhunk://#diff-6f2547d61da244618a0393530bda6d2fc5a64ef82d280e37ec6409de0ead250aR525-R529)

Merging this PR closes #57.