### PR TITLE
Add service-independent publication metadata model

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,6 +5,7 @@ dependencies:
 - hatch-vcs =0.5.0
 - python >=3.11,<3.14
 - pandas =3.0.3
+- pydantic >=2.0,<3.0
 - rdflib =7.6.0
 - requests =2.34.2
 - sparqlwrapper =2.0.0

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - hatch-vcs =0.5.0
 - python >=3.11,<3.14
 - pandas =3.0.3
-- pydantic >=2.0,<3.0
+- pydantic =2.13.4
 - rdflib =7.6.0
 - requests =2.34.2
 - sparqlwrapper =2.0.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,6 +5,7 @@ dependencies:
 - hatch-vcs =0.5.0
 - python >=3.11,<3.14
 - pandas =3.0.3
+- pydantic >=2.0,<3.0
 - rdflib =7.6.0
 - requests =2.34.2
 - sparqlwrapper =2.0.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - hatch-vcs =0.5.0
 - python >=3.11,<3.14
 - pandas =3.0.3
-- pydantic >=2.0,<3.0
+- pydantic =2.13.4
 - rdflib =7.6.0
 - requests =2.34.2
 - sparqlwrapper =2.0.0

--- a/.ci_support/lower-bounds.yml
+++ b/.ci_support/lower-bounds.yml
@@ -5,6 +5,7 @@ dependencies:
 - hatch-vcs =0.5.0
 - python =3.11
 - pandas =3.0.0
+- pydantic =2.0.0
 - requests =2.32.5
 - sparqlwrapper =2.0.0
   

--- a/courier/metadata.py
+++ b/courier/metadata.py
@@ -1,0 +1,143 @@
+"""Service-independent publication metadata models."""
+
+from __future__ import annotations
+
+from dataclasses import field
+from datetime import date
+from typing import Self
+
+from pydantic import ConfigDict, field_validator, model_validator
+from pydantic.dataclasses import dataclass
+
+_MODEL_CONFIG = ConfigDict(validate_assignment=True)
+
+__all__ = [
+    "Contributor",
+    "Person",
+    "PublicationMetadata",
+    "RelatedIdentifier",
+]
+
+
+@dataclass(config=_MODEL_CONFIG)
+class Person:
+    """Person identity used by publication metadata."""
+
+    family_name: str | None = None
+    given_names: str | None = None
+    name: str | None = None
+    affiliation: str | None = None
+    orcid: str | None = None
+    gnd: str | None = None
+
+    @field_validator(
+        "family_name",
+        "given_names",
+        "name",
+        "affiliation",
+        "orcid",
+        "gnd",
+        mode="after",
+    )
+    @classmethod
+    def _clean_optional_text(cls, value: str | None) -> str | None:
+        return _optional_text(value)
+
+    @model_validator(mode="after")
+    def _validate_identity(self) -> Self:
+        if self.name or (self.family_name and self.given_names):
+            return self
+        raise ValueError(
+            "person requires either name or both family_name and given_names"
+        )
+
+
+@dataclass(config=_MODEL_CONFIG)
+class Contributor:
+    """Publication contributor with an optional service-neutral role."""
+
+    person: Person
+    role: str | None = None
+
+    @field_validator("role", mode="after")
+    @classmethod
+    def _clean_role(cls, value: str | None) -> str | None:
+        return _optional_text(value)
+
+
+@dataclass(config=_MODEL_CONFIG)
+class RelatedIdentifier:
+    """Reference to a related persistent identifier."""
+
+    identifier: str
+    relation: str
+    resource_type: str | None = None
+
+    @field_validator("identifier", "relation", mode="after")
+    @classmethod
+    def _clean_required_text(cls, value: str) -> str:
+        return _required_text(value)
+
+    @field_validator("resource_type", mode="after")
+    @classmethod
+    def _clean_resource_type(cls, value: str | None) -> str | None:
+        return _optional_text(value)
+
+
+@dataclass(config=_MODEL_CONFIG)
+class PublicationMetadata:
+    """Reusable publication metadata independent of a publication service."""
+
+    title: str
+    description: str
+    creators: list[Person]
+    publication_date: date | None = None
+    contributors: list[Contributor] = field(default_factory=list)
+    keywords: list[str] = field(default_factory=list)
+    license: str | None = None
+    doi: str | None = None
+    version: str | None = None
+    language: str | None = None
+    related_identifiers: list[RelatedIdentifier] = field(default_factory=list)
+
+    @field_validator("title", "description", mode="after")
+    @classmethod
+    def _clean_required_text(cls, value: str) -> str:
+        return _required_text(value)
+
+    @field_validator(
+        "license",
+        "doi",
+        "version",
+        "language",
+        mode="after",
+    )
+    @classmethod
+    def _clean_optional_text(cls, value: str | None) -> str | None:
+        return _optional_text(value)
+
+    @field_validator("keywords", mode="after")
+    @classmethod
+    def _clean_keywords(cls, value: list[str]) -> list[str]:
+        keywords = [_required_text(keyword) for keyword in value]
+        return keywords
+
+    @model_validator(mode="after")
+    def _validate_creators(self) -> Self:
+        if self.creators:
+            return self
+        raise ValueError("creators must contain at least one person")
+
+
+def _required_text(value: str) -> str:
+    text = value.strip()
+    if not text:
+        raise ValueError("value must be a non-empty string")
+    return text
+
+
+def _optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    text = value.strip()
+    return text or None

--- a/courier/metadata.py
+++ b/courier/metadata.py
@@ -90,15 +90,15 @@ class PublicationMetadata:
 
     title: str
     description: str
-    creators: list[Person]
+    creators: tuple[Person, ...]
     publication_date: date | None = None
-    contributors: list[Contributor] = field(default_factory=list)
-    keywords: list[str] = field(default_factory=list)
+    contributors: tuple[Contributor, ...] = field(default_factory=tuple)
+    keywords: tuple[str, ...] = field(default_factory=tuple)
     license: str | None = None
     doi: str | None = None
     version: str | None = None
     language: str | None = None
-    related_identifiers: list[RelatedIdentifier] = field(default_factory=list)
+    related_identifiers: tuple[RelatedIdentifier, ...] = field(default_factory=tuple)
 
     @field_validator("title", "description", mode="after")
     @classmethod
@@ -118,9 +118,8 @@ class PublicationMetadata:
 
     @field_validator("keywords", mode="after")
     @classmethod
-    def _clean_keywords(cls, value: list[str]) -> list[str]:
-        keywords = [_required_text(keyword) for keyword in value]
-        return keywords
+    def _clean_keywords(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(_required_text(keyword) for keyword in value)
 
     @model_validator(mode="after")
     def _validate_creators(self) -> Self:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 - hatch-vcs =0.5.0
 - python >=3.11,<3.14
 - pandas =3.0.3
+- pydantic >=2.0,<3.0
 - rdflib =7.6.0
 - requests =2.34.2
 - sparqlwrapper =2.0.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - hatch-vcs =0.5.0
 - python >=3.11,<3.14
 - pandas =3.0.3
-- pydantic >=2.0,<3.0
+- pydantic =2.13.4
 - rdflib =7.6.0
 - requests =2.34.2
 - sparqlwrapper =2.0.0

--- a/notebooks/ZenodoClient.ipynb
+++ b/notebooks/ZenodoClient.ipynb
@@ -155,7 +155,7 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'software',\n",
-       " 'publication_date': '2026-05-19',\n",
+       " 'publication_date': '2026-05-28',\n",
        " 'title': 'courier Zenodo sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'Small demonstration upload created with courier.',\n",
@@ -185,7 +185,7 @@
      "data": {
       "text/plain": [
        "{'metadata': {'upload_type': 'software',\n",
-       "  'publication_date': '2026-05-19',\n",
+       "  'publication_date': '2026-05-28',\n",
        "  'title': 'courier Zenodo sandbox demo',\n",
        "  'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        "  'description': 'Small demonstration upload created with courier.',\n",
@@ -224,7 +224,7 @@
     {
      "data": {
       "text/plain": [
-       "502048"
+       "505365"
       ]
      },
      "execution_count": 7,
@@ -268,7 +268,7 @@
     {
      "data": {
       "text/plain": [
-       "'https://sandbox.zenodo.org/deposit/502048'"
+       "'https://sandbox.zenodo.org/deposit/505365'"
       ]
      },
      "execution_count": 9,
@@ -301,7 +301,7 @@
      "data": {
       "text/plain": [
        "{'upload_type': 'software',\n",
-       " 'publication_date': '2026-05-19',\n",
+       " 'publication_date': '2026-05-28',\n",
        " 'title': 'courier Zenodo sandbox demo',\n",
        " 'creators': [{'name': 'Doe, Jane', 'affiliation': 'Example Institute'}],\n",
        " 'description': 'Small demonstration upload created with courier.',\n",
@@ -501,8 +501,8 @@
    "outputs": [],
    "source": [
     "published = None\n",
-    "#published = client.depositions.publish(draft)\n",
-    "#published.links.html"
+    "# published = client.depositions.publish(draft)\n",
+    "# published.links.html"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "pandas==3.0.3",
-    "pydantic>=2.0,<3.0",
+    "pydantic==2.13.4",
     "rdflib==7.6.0",
     "requests==2.34.2",
     "sparqlwrapper==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "pandas==3.0.3",
+    "pydantic>=2.0,<3.0",
     "rdflib==7.6.0",
     "requests==2.34.2",
     "sparqlwrapper==2.0.0",

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -44,7 +44,7 @@ class TestPublicationMetadata(unittest.TestCase):
         self.assertEqual(metadata.creators[0].family_name, "Doe")
         self.assertEqual(metadata.contributors[0].person.name, "Curator, Chris")
         self.assertEqual(metadata.contributors[0].role, "DataCurator")
-        self.assertEqual(metadata.keywords, ["python", "publishing"])
+        self.assertEqual(metadata.keywords, ("python", "publishing"))
         self.assertEqual(metadata.license, "Apache-2.0")
         self.assertEqual(metadata.doi, "10.1234/example")
         self.assertEqual(metadata.version, "1.0.0")
@@ -180,6 +180,24 @@ class TestPublicationMetadata(unittest.TestCase):
             metadata.title = " "
         with self.assertRaisesRegex(PydanticValidationError, "creators"):
             metadata.creators = []
+
+    def test_collection_fields_are_immutable_after_validation(self):
+        metadata = PublicationMetadata(
+            title="Dataset",
+            description="Reusable data.",
+            creators=[Person(name="Doe, Jane")],
+            keywords=["data"],
+        )
+
+        self.assertIsInstance(metadata.creators, tuple)
+        self.assertIsInstance(metadata.contributors, tuple)
+        self.assertIsInstance(metadata.keywords, tuple)
+        self.assertIsInstance(metadata.related_identifiers, tuple)
+
+        with self.assertRaises(AttributeError):
+            metadata.creators.clear()
+        with self.assertRaises(AttributeError):
+            metadata.keywords.append(" ")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -88,6 +88,25 @@ class TestPublicationMetadata(unittest.TestCase):
 
         self.assertIsNone(metadata.publication_date)
 
+    def test_optional_text_fields_accept_none(self):
+        person = Person(
+            name="Doe, Jane",
+            affiliation=None,
+        )
+        contributor = Contributor(
+            person=person,
+            role=None,
+        )
+        related_identifier = RelatedIdentifier(
+            identifier="10.1234/example",
+            relation="cites",
+            resource_type=None,
+        )
+
+        self.assertIsNone(person.affiliation)
+        self.assertIsNone(contributor.role)
+        self.assertIsNone(related_identifier.resource_type)
+
     def test_person_requires_name_or_structured_name_parts(self):
         with self.assertRaisesRegex(PydanticValidationError, "person requires"):
             Person()

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -1,0 +1,167 @@
+import unittest
+from datetime import date
+
+from pydantic import ValidationError as PydanticValidationError
+
+from courier.metadata import (
+    Contributor,
+    Person,
+    PublicationMetadata,
+    RelatedIdentifier,
+)
+
+
+class TestPublicationMetadata(unittest.TestCase):
+    def test_publication_metadata_accepts_reusable_fields(self):
+        metadata = PublicationMetadata(
+            title=" courier ",
+            description=" Python client. ",
+            publication_date="2026-04-21",
+            creators=[Person(family_name=" Doe ", given_names=" Jane ")],
+            contributors=[
+                Contributor(
+                    person=Person(name=" Curator, Chris "),
+                    role=" DataCurator ",
+                )
+            ],
+            keywords=[" python ", " publishing "],
+            license=" Apache-2.0 ",
+            doi=" 10.1234/example ",
+            version=" 1.0.0 ",
+            language=" eng ",
+            related_identifiers=[
+                RelatedIdentifier(
+                    identifier=" 10.1234/data ",
+                    relation=" isSupplementedBy ",
+                    resource_type=" dataset ",
+                )
+            ],
+        )
+
+        self.assertEqual(metadata.title, "courier")
+        self.assertEqual(metadata.description, "Python client.")
+        self.assertEqual(metadata.publication_date, date(2026, 4, 21))
+        self.assertEqual(metadata.creators[0].family_name, "Doe")
+        self.assertEqual(metadata.contributors[0].person.name, "Curator, Chris")
+        self.assertEqual(metadata.contributors[0].role, "DataCurator")
+        self.assertEqual(metadata.keywords, ["python", "publishing"])
+        self.assertEqual(metadata.license, "Apache-2.0")
+        self.assertEqual(metadata.doi, "10.1234/example")
+        self.assertEqual(metadata.version, "1.0.0")
+        self.assertEqual(metadata.language, "eng")
+        self.assertEqual(
+            metadata.related_identifiers[0].identifier,
+            "10.1234/data",
+        )
+
+    def test_publication_metadata_coerces_nested_dicts(self):
+        metadata = PublicationMetadata(
+            title="Dataset",
+            description="Reusable data.",
+            creators=[{"name": "Doe, Jane"}],
+            contributors=[
+                {
+                    "person": {"family_name": "Curator", "given_names": "Chris"},
+                    "role": "DataCurator",
+                }
+            ],
+            related_identifiers=[
+                {
+                    "identifier": "10.1234/paper",
+                    "relation": "isSupplementTo",
+                }
+            ],
+        )
+
+        self.assertIsInstance(metadata.creators[0], Person)
+        self.assertEqual(metadata.creators[0].name, "Doe, Jane")
+        self.assertIsInstance(metadata.contributors[0], Contributor)
+        self.assertIsInstance(metadata.contributors[0].person, Person)
+        self.assertIsInstance(metadata.related_identifiers[0], RelatedIdentifier)
+
+    def test_publication_date_has_no_default(self):
+        metadata = PublicationMetadata(
+            title="Dataset",
+            description="Reusable data.",
+            creators=[Person(name="Doe, Jane")],
+        )
+
+        self.assertIsNone(metadata.publication_date)
+
+    def test_person_requires_name_or_structured_name_parts(self):
+        with self.assertRaisesRegex(PydanticValidationError, "person requires"):
+            Person()
+
+        with self.assertRaisesRegex(PydanticValidationError, "person requires"):
+            Person(family_name="Doe")
+
+    def test_publication_metadata_requires_non_empty_core_fields(self):
+        cases = [
+            (
+                {
+                    "title": "",
+                    "description": "Data.",
+                    "creators": [Person(name="Doe, Jane")],
+                },
+                "non-empty string",
+            ),
+            (
+                {
+                    "title": "Dataset",
+                    "description": " ",
+                    "creators": [Person(name="Doe, Jane")],
+                },
+                "non-empty string",
+            ),
+            (
+                {
+                    "title": "Dataset",
+                    "description": "Data.",
+                    "creators": [],
+                },
+                "creators",
+            ),
+        ]
+
+        for kwargs, message in cases:
+            with (
+                self.subTest(kwargs=kwargs),
+                self.assertRaisesRegex(PydanticValidationError, message),
+            ):
+                PublicationMetadata(**kwargs)
+
+    def test_related_identifier_requires_non_empty_identifier_and_relation(self):
+        cases = [
+            ({"identifier": "", "relation": "cites"}, "non-empty string"),
+            ({"identifier": "10.1234/example", "relation": " "}, "non-empty string"),
+        ]
+
+        for kwargs, message in cases:
+            with (
+                self.subTest(kwargs=kwargs),
+                self.assertRaisesRegex(PydanticValidationError, message),
+            ):
+                RelatedIdentifier(**kwargs)
+
+    def test_assignment_is_validated(self):
+        metadata = PublicationMetadata(
+            title="Dataset",
+            description="Reusable data.",
+            creators=[Person(name="Doe, Jane")],
+        )
+
+        metadata.publication_date = "2026-05-01"
+        metadata.creators = [{"name": "Curator, Chris"}]
+
+        self.assertEqual(metadata.publication_date, date(2026, 5, 1))
+        self.assertIsInstance(metadata.creators[0], Person)
+        self.assertEqual(metadata.creators[0].name, "Curator, Chris")
+
+        with self.assertRaisesRegex(PydanticValidationError, "non-empty string"):
+            metadata.title = " "
+        with self.assertRaisesRegex(PydanticValidationError, "creators"):
+            metadata.creators = []
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces a reusable publication metadata model outside the Zenodo service layer. The goal is to separate common publication metadata concepts from Zenodo-specific API fields, so future publication backends can reuse the same core model without depending on `courier.services.zenodo`.

## Summary
- Kept existing Zenodo metadata generation unchanged. **`ZenodoMetadata` is not refactored in this PR.**
- Added `pydantic` as a project and CI environment dependency.
- Added `courier.metadata` with service-neutral pydantic dataclasses:
  - `Person`: reusable person identity for creators and contributors, with name or structured name parts.
  - `Contributor`: wraps a Person with an optional service-neutral role.
  - `RelatedIdentifier`: models references to related persistent identifiers.
  - `PublicationMetadata`: common publication metadata such as title, description, creators, publication date, keywords, license, DOI, version, language, contributors, and related identifiers.

### Example:
```py
from courier.metadata import (
    Contributor,
    Person,
    PublicationMetadata,
    RelatedIdentifier,
)

creator = Person(
    family_name="Doe",
    given_names="Jane",
    affiliation="Example University",
    orcid="0000-0002-1825-0097",
)

contributor = Contributor(
    person=Person(name="Smith, Chris", affiliation="Data Center"),
    role="DataCurator",
)

related_identifier = RelatedIdentifier(
    identifier="10.5281/zenodo.1234567",
    relation="isSupplementTo",
    resource_type="dataset",
)

metadata = PublicationMetadata(
    title="Analysis workflow",
    description="Workflow used to generate the published results.",
    creators=[creator],
    publication_date="2026-05-28",
    contributors=[contributor],
    keywords=["workflow", "publication", "metadata"],
    license="MIT",
    doi="10.1234/example",
    version="1.0.0",
    language="eng",
    related_identifiers=[related_identifier],
)
```
## Unit Tests
Added focused tests for the new common metadata model covering:
- construction with reusable publication fields
- nested `dict` coercion into dataclasses
- date coercion
- no implicit `publication_date` default
- required creator/person validation
- non-empty string validation
- assignment validation

Existing Zenodo metadata/deposition tests continue to pass, confirming the current Zenodo payload generation path remains compatible.