### PR TITLE
Refactor/zenodo metadata adapter

### DIFF
--- a/courier/services/zenodo/metadata.py
+++ b/courier/services/zenodo/metadata.py
@@ -380,9 +380,7 @@ class ZenodoMetadata:
         if self.metadata is not None:
             return list(self.metadata.keywords)
         return [
-            keyword.strip()
-            for keyword in self.keywords
-            if keyword and keyword.strip()
+            keyword.strip() for keyword in self.keywords if keyword and keyword.strip()
         ]
 
     def _related_identifiers(

--- a/courier/services/zenodo/metadata.py
+++ b/courier/services/zenodo/metadata.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from typing import Any
 
+import courier.metadata as common_metadata
 from courier.exceptions import ValidationError
 
 _UPLOAD_TYPES = {
@@ -22,6 +23,19 @@ _UPLOAD_TYPES = {
     "video",
 }
 _ACCESS_RIGHTS = {"closed", "embargoed", "open", "restricted"}
+_COMMON_METADATA_FIELDS = {
+    "publication_date",
+    "title",
+    "creators",
+    "description",
+    "license",
+    "doi",
+    "keywords",
+    "related_identifiers",
+    "contributors",
+    "version",
+    "language",
+}
 
 
 @dataclass
@@ -142,21 +156,28 @@ class ZenodoMetadata:
     grants: list[GrantRef] = field(default_factory=list)
     version: str | None = None
     language: str | None = "eng"
+    metadata: common_metadata.PublicationMetadata | None = None
 
     def validate(self) -> None:
         """Validate local metadata requirements before submission."""
+        self._validate_publication_metadata_boundary()
+
         upload_type = _required_string(self.upload_type, "upload_type")
         if upload_type not in _UPLOAD_TYPES:
             raise ValidationError(f"unsupported upload_type: {upload_type!r}")
 
-        _ = _date_string(self.publication_date, "publication_date")
-        _ = _required_string(self.title, "title")
-        _ = _required_string(self.description, "description")
+        _ = _date_string(self._publication_date(), "publication_date")
+        _ = _required_string(self._title(), "title")
+        _ = _required_string(self._description(), "description")
 
-        if not self.creators:
+        creators = self._creators()
+        if not creators:
             raise ValidationError("creators must contain at least one creator")
-        for creator in self.creators:
-            creator.validate()
+        for creator in creators:
+            if isinstance(creator, Creator):
+                creator.validate()
+            else:
+                _ = _person_api_name(creator)
 
         if upload_type == "publication":
             _ = _required_string(self.publication_type, "publication_type")
@@ -167,7 +188,7 @@ class ZenodoMetadata:
         if access_right not in _ACCESS_RIGHTS:
             raise ValidationError(f"unsupported access_right: {access_right!r}")
         if access_right in {"open", "embargoed"}:
-            _ = _required_string(self.license, "license")
+            _ = _required_string(self._license(), "license")
         if access_right == "embargoed":
             _ = _date_string(self.embargo_date, "embargo_date")
         if access_right == "restricted":
@@ -180,39 +201,37 @@ class ZenodoMetadata:
         data: dict[str, Any] = {
             "upload_type": _required_string(self.upload_type, "upload_type"),
             "publication_date": _date_string(
-                self.publication_date,
+                self._publication_date(),
                 "publication_date",
             ),
-            "title": _required_string(self.title, "title"),
-            "creators": [creator.to_api_dict() for creator in self.creators],
-            "description": _required_string(self.description, "description"),
+            "title": _required_string(self._title(), "title"),
+            "creators": [_creator_to_api_dict(creator) for creator in self._creators()],
+            "description": _required_string(self._description(), "description"),
             "access_right": _required_string(self.access_right, "access_right"),
         }
 
         _add_if_present(data, "publication_type", self.publication_type)
         _add_if_present(data, "image_type", self.image_type)
-        _add_if_present(data, "license", self.license)
+        _add_if_present(data, "license", self._license())
         _add_if_present(data, "embargo_date", _optional_date_string(self.embargo_date))
         _add_if_present(data, "access_conditions", self.access_conditions)
-        _add_if_present(data, "doi", self.doi)
+        _add_if_present(data, "doi", self._doi())
         if self.prereserve_doi is not None:
             data["prereserve_doi"] = self.prereserve_doi
-        if self.keywords:
-            keywords = [
-                keyword.strip()
-                for keyword in self.keywords
-                if keyword and keyword.strip()
-            ]
-            if keywords:
-                data["keywords"] = keywords
+        keywords = self._keywords()
+        if keywords:
+            data["keywords"] = keywords
         _add_if_present(data, "notes", self.notes)
-        if self.related_identifiers:
+        related_identifiers = self._related_identifiers()
+        if related_identifiers:
             data["related_identifiers"] = [
-                related.to_api_dict() for related in self.related_identifiers
+                _related_identifier_to_api_dict(related)
+                for related in related_identifiers
             ]
-        if self.contributors:
+        contributors = self._contributors()
+        if contributors:
             data["contributors"] = [
-                contributor.to_api_dict() for contributor in self.contributors
+                _contributor_to_api_dict(contributor) for contributor in contributors
             ]
         if self.communities:
             data["communities"] = [
@@ -220,8 +239,8 @@ class ZenodoMetadata:
             ]
         if self.grants:
             data["grants"] = [grant.to_api_dict() for grant in self.grants]
-        _add_if_present(data, "version", self.version)
-        _add_if_present(data, "language", self.language)
+        _add_if_present(data, "version", self._version())
+        _add_if_present(data, "language", self._language())
         return data
 
     def to_payload(self) -> dict[str, Any]:
@@ -268,20 +287,38 @@ class ZenodoMetadata:
         )
 
     @classmethod
-    def software(cls) -> ZenodoMetadata:
-        return cls(upload_type="software")
+    def software(
+        cls,
+        metadata: common_metadata.PublicationMetadata | None = None,
+    ) -> ZenodoMetadata:
+        return cls(upload_type="software", metadata=metadata)
 
     @classmethod
-    def dataset(cls) -> ZenodoMetadata:
-        return cls(upload_type="dataset")
+    def dataset(
+        cls,
+        metadata: common_metadata.PublicationMetadata | None = None,
+    ) -> ZenodoMetadata:
+        return cls(upload_type="dataset", metadata=metadata)
 
     @classmethod
-    def publication(cls, publication_type: str) -> ZenodoMetadata:
-        return cls(upload_type="publication", publication_type=publication_type)
+    def publication(
+        cls,
+        publication_type: str,
+        metadata: common_metadata.PublicationMetadata | None = None,
+    ) -> ZenodoMetadata:
+        return cls(
+            upload_type="publication",
+            publication_type=publication_type,
+            metadata=metadata,
+        )
 
     @classmethod
-    def image(cls, image_type: str) -> ZenodoMetadata:
-        return cls(upload_type="image", image_type=image_type)
+    def image(
+        cls,
+        image_type: str,
+        metadata: common_metadata.PublicationMetadata | None = None,
+    ) -> ZenodoMetadata:
+        return cls(upload_type="image", image_type=image_type, metadata=metadata)
 
     def add_creator(self, **kwargs: Any) -> Creator:
         creator = Creator(**kwargs)
@@ -309,11 +346,148 @@ class ZenodoMetadata:
         self.grants.append(grant)
         return grant
 
+    def _publication_date(self) -> date | str | None:
+        if self.metadata is None:
+            return self.publication_date
+        return self.metadata.publication_date
+
+    def _title(self) -> str | None:
+        if self.metadata is None:
+            return self.title
+        return self.metadata.title
+
+    def _description(self) -> str | None:
+        if self.metadata is None:
+            return self.description
+        return self.metadata.description
+
+    def _creators(self) -> tuple[common_metadata.Person, ...] | list[Creator]:
+        if self.metadata is None:
+            return self.creators
+        return self.metadata.creators
+
+    def _license(self) -> str | None:
+        if self.metadata is None:
+            return self.license
+        return self.metadata.license
+
+    def _doi(self) -> str | None:
+        if self.metadata is None:
+            return self.doi
+        return self.metadata.doi
+
+    def _keywords(self) -> list[str]:
+        if self.metadata is not None:
+            return list(self.metadata.keywords)
+        return [
+            keyword.strip()
+            for keyword in self.keywords
+            if keyword and keyword.strip()
+        ]
+
+    def _related_identifiers(
+        self,
+    ) -> tuple[common_metadata.RelatedIdentifier, ...] | list[RelatedIdentifier]:
+        if self.metadata is None:
+            return self.related_identifiers
+        return self.metadata.related_identifiers
+
+    def _contributors(
+        self,
+    ) -> tuple[common_metadata.Contributor, ...] | list[Contributor]:
+        if self.metadata is None:
+            return self.contributors
+        return self.metadata.contributors
+
+    def _version(self) -> str | None:
+        if self.metadata is None:
+            return self.version
+        return self.metadata.version
+
+    def _language(self) -> str | None:
+        if self.metadata is None:
+            return self.language
+        return self.metadata.language or self.language
+
+    def _validate_publication_metadata_boundary(self) -> None:
+        if self.metadata is None:
+            return
+
+        conflicts = [
+            field_name
+            for field_name in _COMMON_METADATA_FIELDS
+            if self._has_legacy_common_field_value(field_name)
+        ]
+        if conflicts:
+            joined = ", ".join(conflicts)
+            raise ValidationError(
+                "cannot set Zenodo common metadata fields when metadata is provided: "
+                f"{joined}"
+            )
+
+    def _has_legacy_common_field_value(self, field_name: str) -> bool:
+        value = getattr(self, field_name)
+        if field_name == "language":
+            return value not in {None, "eng"}
+        if isinstance(value, list):
+            return bool(value)
+        return value is not None
+
 
 def _required_string(value: object, field_name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValidationError(f"{field_name} must be a non-empty string")
     return value.strip()
+
+
+def _creator_to_api_dict(
+    creator: Creator | common_metadata.Person,
+) -> dict[str, str]:
+    if isinstance(creator, Creator):
+        return creator.to_api_dict()
+    data = {"name": _person_api_name(creator)}
+    _add_if_present(data, "affiliation", creator.affiliation)
+    _add_if_present(data, "orcid", creator.orcid)
+    _add_if_present(data, "gnd", creator.gnd)
+    return data
+
+
+def _person_api_name(person: common_metadata.Person) -> str:
+    if person.name:
+        return person.name
+    if person.family_name and person.given_names:
+        return f"{person.family_name}, {person.given_names}"
+    raise ValidationError(
+        "person requires either name or both family_name and given_names"
+    )
+
+
+def _related_identifier_to_api_dict(
+    related_identifier: RelatedIdentifier | common_metadata.RelatedIdentifier,
+) -> dict[str, str]:
+    if isinstance(related_identifier, RelatedIdentifier):
+        return related_identifier.to_api_dict()
+    data = {
+        "identifier": _required_string(related_identifier.identifier, "identifier"),
+        "relation": _required_string(related_identifier.relation, "relation"),
+    }
+    _add_if_present(data, "resource_type", related_identifier.resource_type)
+    return data
+
+
+def _contributor_to_api_dict(
+    contributor: Contributor | common_metadata.Contributor,
+) -> dict[str, str]:
+    if isinstance(contributor, Contributor):
+        return contributor.to_api_dict()
+    data = {
+        "name": _person_api_name(contributor.person),
+        "type": _required_string(contributor.role, "contributor role"),
+    }
+    _add_if_present(data, "affiliation", contributor.person.affiliation)
+    _add_if_present(data, "orcid", contributor.person.orcid)
+    _add_if_present(data, "gnd", contributor.person.gnd)
+    return data
 
 
 def _optional_string(value: object) -> str | None:

--- a/tests/unit/services/zenodo/test_metadata.py
+++ b/tests/unit/services/zenodo/test_metadata.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import date
 
+import courier.metadata as common_metadata
 from courier.exceptions import ValidationError
 from courier.services.zenodo import (
     CommunityRef,
@@ -10,7 +11,7 @@ from courier.services.zenodo import (
     RelatedIdentifier,
     ZenodoMetadata,
 )
-from courier.services.zenodo.metadata import _add_if_present
+from courier.services.zenodo.metadata import _add_if_present, _person_api_name
 
 
 def _valid_metadata(**overrides):
@@ -25,6 +26,18 @@ def _valid_metadata(**overrides):
     }
     values.update(overrides)
     return ZenodoMetadata(**values)
+
+
+def _valid_publication_metadata(**overrides):
+    values = {
+        "title": "courier",
+        "publication_date": "2026-04-21",
+        "description": "Python client.",
+        "creators": [common_metadata.Person(family_name="Doe", given_names="Jane")],
+        "license": "Apache-2.0",
+    }
+    values.update(overrides)
+    return common_metadata.PublicationMetadata(**values)
 
 
 class TestZenodoMetadata(unittest.TestCase):
@@ -79,6 +92,142 @@ class TestZenodoMetadata(unittest.TestCase):
         self.assertEqual(md.communities[0].identifier, "pyiron")
         self.assertEqual(md.grants[0].id, "10.13039/501100000000::12345")
         self.assertEqual(md.to_api_dict()["publication_date"], "2026-04-21")
+
+    def test_publication_metadata_serializes_to_zenodo_payload(self):
+        publication = _valid_publication_metadata(
+            creators=[
+                common_metadata.Person(
+                    family_name="Doe",
+                    given_names="Jane",
+                    affiliation="CERN",
+                    orcid="0000-0000-0000-0000",
+                    gnd="123",
+                )
+            ],
+            contributors=[
+                common_metadata.Contributor(
+                    person=common_metadata.Person(
+                        name="Curator, Chris",
+                        affiliation="CERN",
+                    ),
+                    role="DataCurator",
+                )
+            ],
+            keywords=["python", "client"],
+            doi="10.1234/example",
+            version="1.0.0",
+            language="eng",
+            related_identifiers=[
+                common_metadata.RelatedIdentifier(
+                    identifier="10.1234/data",
+                    relation="isSupplementedBy",
+                    resource_type="dataset",
+                )
+            ],
+        )
+
+        md = ZenodoMetadata.software(publication)
+        payload = md.to_payload()
+
+        self.assertDictEqual(
+            payload,
+            {
+                "metadata": {
+                    "upload_type": "software",
+                    "publication_date": "2026-04-21",
+                    "title": "courier",
+                    "creators": [
+                        {
+                            "name": "Doe, Jane",
+                            "affiliation": "CERN",
+                            "orcid": "0000-0000-0000-0000",
+                            "gnd": "123",
+                        }
+                    ],
+                    "description": "Python client.",
+                    "access_right": "open",
+                    "license": "Apache-2.0",
+                    "doi": "10.1234/example",
+                    "keywords": ["python", "client"],
+                    "related_identifiers": [
+                        {
+                            "identifier": "10.1234/data",
+                            "relation": "isSupplementedBy",
+                            "resource_type": "dataset",
+                        }
+                    ],
+                    "contributors": [
+                        {
+                            "name": "Curator, Chris",
+                            "type": "DataCurator",
+                            "affiliation": "CERN",
+                        }
+                    ],
+                    "version": "1.0.0",
+                    "language": "eng",
+                }
+            },
+        )
+
+    def test_publication_metadata_keeps_zenodo_specific_fields_on_adapter(self):
+        publication = _valid_publication_metadata()
+        md = ZenodoMetadata.publication(
+            "article",
+            publication,
+        )
+        md.prereserve_doi = True
+        md.notes = "Release notes."
+        md.add_community("pyiron")
+        md.add_grant("grant-1")
+
+        payload = md.to_api_dict()
+
+        self.assertEqual(payload["publication_type"], "article")
+        self.assertTrue(payload["prereserve_doi"])
+        self.assertEqual(payload["notes"], "Release notes.")
+        self.assertEqual(payload["communities"], [{"identifier": "pyiron"}])
+        self.assertEqual(payload["grants"], [{"id": "grant-1"}])
+
+    def test_publication_metadata_rejects_duplicate_common_fields(self):
+        publication = _valid_publication_metadata()
+        cases = [
+            ({"title": "legacy"}, "title"),
+            ({"creators": [Creator(name="Legacy, Creator")]}, "creators"),
+            ({"keywords": ["legacy"]}, "keywords"),
+            ({"language": "deu"}, "language"),
+        ]
+
+        for kwargs, message in cases:
+            with (
+                self.subTest(kwargs=kwargs),
+                self.assertRaisesRegex(ValidationError, message),
+            ):
+                ZenodoMetadata(
+                    metadata=publication,
+                    upload_type="software",
+                    **kwargs,
+                ).validate()
+
+    def test_publication_metadata_contributor_requires_role_for_zenodo(self):
+        publication = _valid_publication_metadata(
+            contributors=[
+                common_metadata.Contributor(
+                    person=common_metadata.Person(name="Curator, Chris"),
+                )
+            ],
+        )
+
+        with self.assertRaisesRegex(ValidationError, "contributor role"):
+            ZenodoMetadata.software(publication).to_api_dict()
+
+    def test_publication_person_adapter_rejects_invalid_identity(self):
+        person = object.__new__(common_metadata.Person)
+        object.__setattr__(person, "name", None)
+        object.__setattr__(person, "family_name", None)
+        object.__setattr__(person, "given_names", None)
+
+        with self.assertRaisesRegex(ValidationError, "person requires"):
+            _person_api_name(person)
 
     def test_creator_can_use_explicit_name(self):
         creator = Creator(name="Zenodo Team", affiliation="CERN")


### PR DESCRIPTION
This PR adds an adapter path from the service-independent `PublicationMetadata` model to Zenodo deposition metadata. `ZenodoMetadata` can now wrap a `PublicationMetadata` instance while keeping Zenodo-specific fields and payload generation inside the Zenodo service layer.

## Summary
- Added optional metadata: `PublicationMetadata` composition to `ZenodoMetadata`.
- Kept existing legacy `ZenodoMetadata` field-based construction working.
- Updated Zenodo convenience constructors to accept common metadata, e.g. `ZenodoMetadata.software(publication)`.
- Mapped common metadata concepts into Zenodo API payloads:
  - `Person` creators -> Zenodo creators
  - `Contributor.role` -> Zenodo contributor type
  - `RelatedIdentifier` -> Zenodo related identifiers
  - common title, description, publication date, license, DOI, version, language, and keywords
- Kept Zenodo-specific fields on `ZenodoMetadata`, including upload type, publication/image type, access control, communities, grants, notes, and DOI reservation.
- Rejected mixed duplicate common fields when metadata is provided, to avoid ambiguous payload generation.
- Did not change deposition resource behavior yet; clients still pass `ZenodoMetadata` or raw mappings.

## Unit Tests
Added focused Zenodo metadata tests covering:
- serialization of `PublicationMetadata` through `ZenodoMetadata`
- convenience constructor usage
- mapping common creators, contributors, and related identifiers into Zenodo payload shape
- keeping Zenodo-specific fields on the adapter
- rejecting duplicate legacy common fields when wrapped metadata is used
- defensive validation for invalid adapted person identity

Existing Zenodo metadata tests continue to cover the legacy field-based path.

## Validation
Validated with:
```sh
ruff check --fix --diff .
python -m mypy courier
pytest -q
coverage run -m pytest -q
coverage combine
coverage report -m
```

## Examples
### Legacy Zenodo Metadata
```py
from courier.services.zenodo import Creator, ZenodoMetadata

metadata = ZenodoMetadata.software()
metadata.title = "courier"
metadata.description = "Python client."
metadata.publication_date = "2026-04-21"
metadata.license = "Apache-2.0"
metadata.creators.append(Creator(name="Doe, Jane"))
metadata.add_keyword("python")

payload = metadata.to_payload()
```
This still works. Common publication fields and Zenodo-specific fields are all set directly on `ZenodoMetadata`.

### New Adapter Style
```py
from courier.metadata import Person, PublicationMetadata
from courier.services.zenodo import ZenodoMetadata

publication = PublicationMetadata(
  title="courier",
  description="Python client.",
  publication_date="2026-04-21",
  creators=[Person(name="Doe, Jane")],
  keywords=["python"],
  license="Apache-2.0",
)

metadata = ZenodoMetadata.software(publication)

payload = metadata.to_payload()
```
Here, reusable publication fields live in `PublicationMetadata`. `ZenodoMetadata` supplies the Zenodo-specific wrapper, especially `upload_type="software"`.

### New Adapter With Zenodo-Specific Fields
```py
from courier.metadata import Person, PublicationMetadata
from courier.services.zenodo import ZenodoMetadata

publication = PublicationMetadata(
  title="Example paper",
  description="Paper metadata.",
  publication_date="2026-04-21",
  creators=[Person(name="Doe, Jane")],
  license="cc-by-4.0",
)

metadata = ZenodoMetadata.publication("article", publication)
metadata.add_community("pyiron")
metadata.add_grant("grant-1")
metadata.prereserve_doi = True
metadata.notes = "Submitted through courier."

payload = metadata.to_payload()
```
This is valid because `publication_type`, communities, grants, DOI reservation, and notes are Zenodo-specific adapter fields.

### Invalid Mixed Usage
```py
from courier.metadata import Person, PublicationMetadata
from courier.services.zenodo import ZenodoMetadata

publication = PublicationMetadata(
  title="courier",
  description="Python client.",
  creators=[Person(name="Doe, Jane")],
  license="Apache-2.0",
)

metadata = ZenodoMetadata(
  metadata=publication,
  upload_type="software",
  title="Different title",
)

metadata.to_payload()
```
This is invalid because `title` is a common publication field. When `metadata=publication` is provided, common fields must come from `PublicationMetadata`, not also from legacy `ZenodoMetadata` fields.

Also invalid:
```py
ZenodoMetadata(
  metadata=publication,
  upload_type="software",
  creators=[Creator(name="Legacy, Creator")],
)
```
and:
```py
ZenodoMetadata(
  metadata=publication,
  upload_type="software",
  keywords=["legacy"],
)
```
These are rejected to avoid ambiguous payload generation.
