### PR TITLE
Test Zenodo client integration for publication metadata

### DIFF
--- a/courier/services/zenodo/depositions.py
+++ b/courier/services/zenodo/depositions.py
@@ -125,6 +125,10 @@ def _metadata_payload(
         return {}
     if isinstance(metadata, ZenodoMetadata):
         return metadata.to_payload()
+    if not isinstance(metadata, Mapping):
+        raise ValidationError(
+            "Zenodo deposition metadata must be ZenodoMetadata, a mapping, or None"
+        )
     payload = dict(metadata)
     if isinstance(payload.get("metadata"), Mapping):
         return payload

--- a/courier/services/zenodo/depositions.py
+++ b/courier/services/zenodo/depositions.py
@@ -125,11 +125,12 @@ def _metadata_payload(
         return {}
     if isinstance(metadata, ZenodoMetadata):
         return metadata.to_payload()
-    if not isinstance(metadata, Mapping):
+    try:
+        payload = dict(metadata)
+    except TypeError as exc:
         raise ValidationError(
             "Zenodo deposition metadata must be ZenodoMetadata, a mapping, or None"
-        )
-    payload = dict(metadata)
+        ) from exc
     if isinstance(payload.get("metadata"), Mapping):
         return payload
     return {"metadata": payload}

--- a/tests/unit/services/zenodo/test_depositions.py
+++ b/tests/unit/services/zenodo/test_depositions.py
@@ -2,12 +2,24 @@ import unittest
 from typing import Any, cast
 
 from courier.exceptions import ValidationError
+from courier.metadata import Person, PublicationMetadata
 from courier.services.zenodo import ZenodoClient
 from courier.services.zenodo._urls import deposition_action_url
 from courier.services.zenodo.metadata import Creator, ZenodoMetadata
 from courier.services.zenodo.models import DepositionInfo
 
 from ._helpers import FakeResponse, FakeSession, deposition_payload
+
+
+def _publication_metadata() -> PublicationMetadata:
+    return PublicationMetadata(
+        title="courier",
+        description="Python client.",
+        publication_date="2026-04-21",
+        creators=[Person(name="Doe, Jane")],
+        keywords=["python"],
+        license="Apache-2.0",
+    )
 
 
 class TestDepositionsResource(unittest.TestCase):
@@ -101,6 +113,39 @@ class TestDepositionsResource(unittest.TestCase):
             "software",
         )
 
+    def test_create_serializes_publication_metadata_adapter(self):
+        metadata = ZenodoMetadata.software(_publication_metadata())
+        session = FakeSession([FakeResponse(json_value=deposition_payload())])
+        c = ZenodoClient(session=cast(Any, session))
+
+        _ = c.depositions.create(metadata)
+
+        self.assertEqual(
+            session.calls[0]["json"],
+            {
+                "metadata": {
+                    "upload_type": "software",
+                    "publication_date": "2026-04-21",
+                    "title": "courier",
+                    "creators": [{"name": "Doe, Jane"}],
+                    "description": "Python client.",
+                    "access_right": "open",
+                    "license": "Apache-2.0",
+                    "keywords": ["python"],
+                    "language": "eng",
+                }
+            },
+        )
+
+    def test_create_adds_prereserved_doi_to_publication_metadata_adapter(self):
+        metadata = ZenodoMetadata.software(_publication_metadata())
+        session = FakeSession([FakeResponse(json_value=deposition_payload())])
+        c = ZenodoClient(session=cast(Any, session))
+
+        _ = c.depositions.create(metadata, prereserve_doi=True)
+
+        self.assertTrue(session.calls[0]["json"]["metadata"]["prereserve_doi"])
+
     def test_get_accepts_deposition_info(self):
         session = FakeSession([FakeResponse(json_value=deposition_payload())])
         c = ZenodoClient(session=cast(Any, session))
@@ -134,6 +179,23 @@ class TestDepositionsResource(unittest.TestCase):
         _ = c.depositions.set_metadata(42, {"metadata": {"title": "Draft"}})
 
         self.assertEqual(session.calls[0]["json"], {"metadata": {"title": "Draft"}})
+
+    def test_set_metadata_serializes_publication_metadata_adapter(self):
+        metadata = ZenodoMetadata.software(_publication_metadata())
+        session = FakeSession([FakeResponse(json_value=deposition_payload())])
+        c = ZenodoClient(session=cast(Any, session))
+
+        _ = c.depositions.set_metadata(42, metadata)
+
+        self.assertEqual(session.calls[0]["method"], "PUT")
+        self.assertEqual(
+            session.calls[0]["json"]["metadata"]["title"],
+            "courier",
+        )
+        self.assertEqual(
+            session.calls[0]["json"]["metadata"]["upload_type"],
+            "software",
+        )
 
     def test_publish_posts_to_action_endpoint(self):
         session = FakeSession(

--- a/tests/unit/services/zenodo/test_depositions.py
+++ b/tests/unit/services/zenodo/test_depositions.py
@@ -197,6 +197,13 @@ class TestDepositionsResource(unittest.TestCase):
             "software",
         )
 
+    def test_plain_publication_metadata_is_rejected(self):
+        session = FakeSession([FakeResponse(json_value=deposition_payload())])
+        c = ZenodoClient(session=cast(Any, session))
+
+        with self.assertRaisesRegex(ValidationError, "ZenodoMetadata"):
+            c.depositions.create(cast(Any, _publication_metadata()))
+
     def test_publish_posts_to_action_endpoint(self):
         session = FakeSession(
             [FakeResponse(status_code=202, json_value=deposition_payload())]


### PR DESCRIPTION
This PR verifies that the Zenodo deposition resource correctly handles the new `PublicationMetadata` adapter path through `ZenodoMetadata`. It keeps the client API explicit: callers still pass `ZenodoMetadata` or raw mappings, while plain `PublicationMetadata` is rejected because it lacks Zenodo-specific metadata such as `upload_type`.

## Summary
- Added deposition resource tests for `ZenodoMetadata.software(publication_metadata)`.
- Covered both `DepositionsResource.create()` and `DepositionsResource.set_metadata()`.
- Verified `create(..., prereserve_doi=True)` still injects DOI reservation into adapter-generated payloads.
- Preserved existing raw mapping behavior.
- Added an explicit runtime guard for unsupported metadata objects.
- Confirmed plain `PublicationMetadata` is not accepted directly by Zenodo deposition methods.

## Unit Tests
Added focused tests in `tests/unit/services/zenodo/test_depositions.py` covering:
- payload generation through `create()` with wrapped publication metadata
- payload generation through `set_metadata()` with wrapped publication metadata
- DOI pre-reservation with wrapped publication metadata
- rejection of plain `PublicationMetadata` with a clear `ValidationError`

## Validation
Validated with:
```sh
ruff check --fix --diff .
python -m mypy courier
pytest -q
coverage run -m pytest -q
coverage combine
coverage report -m
```

**Note:** These are client integration tests in the local/unit-test sense: they verify that the deposition resource serializes and sends the correct request payload through the client boundary. They do not call a live Zenodo service.