### PR TITLE
Deprecate legacy Zenodo metadata authoring

### DIFF
--- a/courier/__init__.py
+++ b/courier/__init__.py
@@ -8,11 +8,16 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
 from courier.http_client import HttpClient
+from courier.metadata import Contributor, Person, PublicationMetadata, RelatedIdentifier
 from courier.services.ontodocker import OntodockerClient
 from courier.services.zenodo import ZenodoClient
 
 __all__ = [
+    "Contributor",
     "HttpClient",
     "OntodockerClient",
+    "Person",
+    "PublicationMetadata",
+    "RelatedIdentifier",
     "ZenodoClient",
 ]

--- a/courier/services/zenodo/metadata.py
+++ b/courier/services/zenodo/metadata.py
@@ -461,7 +461,7 @@ def _warn_legacy_common_metadata(*, stacklevel: int) -> None:
     warnings.warn(
         _LEGACY_COMMON_METADATA_MESSAGE,
         DeprecationWarning,
-        stacklevel=stacklevel,
+        stacklevel=stacklevel + 1,
     )
 
 

--- a/courier/services/zenodo/metadata.py
+++ b/courier/services/zenodo/metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import date
@@ -36,6 +37,11 @@ _COMMON_METADATA_FIELDS = {
     "version",
     "language",
 }
+_LEGACY_COMMON_METADATA_MESSAGE = (
+    "Setting publication metadata fields directly on ZenodoMetadata is deprecated. "
+    "Use courier.PublicationMetadata and wrap it with a ZenodoMetadata adapter, "
+    "for example ZenodoMetadata.software(publication)."
+)
 
 
 @dataclass
@@ -161,6 +167,7 @@ class ZenodoMetadata:
     def validate(self) -> None:
         """Validate local metadata requirements before submission."""
         self._validate_publication_metadata_boundary()
+        self._warn_if_legacy_common_metadata()
 
         upload_type = _required_string(self.upload_type, "upload_type")
         if upload_type not in _UPLOAD_TYPES:
@@ -321,17 +328,20 @@ class ZenodoMetadata:
         return cls(upload_type="image", image_type=image_type, metadata=metadata)
 
     def add_creator(self, **kwargs: Any) -> Creator:
+        _warn_legacy_common_metadata(stacklevel=2)
         creator = Creator(**kwargs)
         self.creators.append(creator)
         return creator
 
     def add_keyword(self, keyword: str) -> None:
+        _warn_legacy_common_metadata(stacklevel=2)
         keyword = keyword.strip()
         if not keyword:
             raise ValidationError("keyword must be non-empty")
         self.keywords.append(keyword)
 
     def add_related_identifier(self, **kwargs: Any) -> RelatedIdentifier:
+        _warn_legacy_common_metadata(stacklevel=2)
         related = RelatedIdentifier(**kwargs)
         self.related_identifiers.append(related)
         return related
@@ -431,11 +441,28 @@ class ZenodoMetadata:
             return bool(value)
         return value is not None
 
+    def _warn_if_legacy_common_metadata(self) -> None:
+        if self.metadata is not None:
+            return
+        if any(
+            self._has_legacy_common_field_value(field_name)
+            for field_name in _COMMON_METADATA_FIELDS
+        ):
+            _warn_legacy_common_metadata(stacklevel=3)
+
 
 def _required_string(value: object, field_name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValidationError(f"{field_name} must be a non-empty string")
     return value.strip()
+
+
+def _warn_legacy_common_metadata(*, stacklevel: int) -> None:
+    warnings.warn(
+        _LEGACY_COMMON_METADATA_MESSAGE,
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )
 
 
 def _creator_to_api_dict(

--- a/docs/README.md
+++ b/docs/README.md
@@ -241,7 +241,7 @@ Create a client and a small artifact:
 import os
 from pathlib import Path
 
-from courier import ZenodoClient
+from courier import Person, PublicationMetadata, ZenodoClient
 from courier.services.zenodo import Creator, ZenodoMetadata
 
 client = ZenodoClient(sandbox=True, token=os.environ["ZENODO_SANDBOX_TOKEN"])
@@ -253,15 +253,39 @@ artifact.write_text(
 )
 ```
 
-Build metadata with the typed authoring model:
+Build service-independent publication metadata and wrap it in the Zenodo
+adapter:
+
+```python
+publication = PublicationMetadata(
+    title="courier Zenodo sandbox demo",
+    description="Small demonstration upload created with courier.",
+    creators=[
+        Person(
+            family_name="Doe",
+            given_names="Jane",
+            affiliation="Example Institute",
+        )
+    ],
+    keywords=["courier", "zenodo", "sandbox"],
+    license="cc-by-4.0",
+    version="0.1.0",
+)
+
+metadata = ZenodoMetadata.software(publication)
+```
+
+Directly setting publication fields such as `title`, `creators`, or `keywords`
+on `ZenodoMetadata` is deprecated. Use `PublicationMetadata` for reusable
+publication fields and `ZenodoMetadata` for Zenodo-specific fields.
+
+The deprecated direct style still works temporarily for migration:
 
 ```python
 metadata = ZenodoMetadata.software()
 metadata.title = "courier Zenodo sandbox demo"
 metadata.description = "Small demonstration upload created with courier."
 metadata.license = "cc-by-4.0"
-metadata.version = "0.1.0"
-
 metadata.creators.append(
     Creator(
         family_name="Doe",
@@ -269,8 +293,6 @@ metadata.creators.append(
         affiliation="Example Institute",
     )
 )
-
-metadata.keywords.extend(["courier", "zenodo", "sandbox"])
 ```
 
 Create an unpublished draft, pre-reserve a DOI, upload the artifact, and set the
@@ -301,24 +323,31 @@ citable scholarly identifier when the record is published.
 
 #### Metadata
 
-`ZenodoMetadata` is a typed authoring object for common Zenodo metadata fields.
-It mirrors Zenodo field names where practical, so the emitted payload remains
-easy to compare with Zenodo's API documentation.
+`PublicationMetadata` is courier's service-independent authoring model for
+publication fields such as title, description, creators, contributors, related
+identifiers, keywords, license, DOI, version, language, and publication date.
+
+`ZenodoMetadata` adapts `PublicationMetadata` into Zenodo's API payload shape and
+keeps Zenodo-specific fields such as upload type, access control, communities,
+grants, DOI reservation, and notes.
 
 Convenience constructors set the upload type:
 
 ```python
-software = ZenodoMetadata.software()
-dataset = ZenodoMetadata.dataset()
-publication = ZenodoMetadata.publication("article")
-image = ZenodoMetadata.image("figure")
+software = ZenodoMetadata.software(publication)
+dataset = ZenodoMetadata.dataset(publication)
+article = ZenodoMetadata.publication("article", publication)
+image = ZenodoMetadata.image("figure", publication)
 ```
 
-Nested helpers model repeated metadata objects:
+Common nested metadata is modeled independently of Zenodo:
 
-- `Creator` for creators and optional affiliation, ORCID, or GND.
-- `Contributor` for additional contributors.
+- `Person` for creators and contributor identities.
+- `Contributor` for additional contributors with a role.
 - `RelatedIdentifier` for related persistent identifiers or URLs.
+
+Zenodo-specific repeated metadata still uses Zenodo helpers:
+
 - `CommunityRef` for Zenodo community identifiers.
 - `GrantRef` for grant references.
 
@@ -338,6 +367,10 @@ request_payload = metadata.to_payload()
 The typed model performs local validation for stable structural rules before a
 request is sent, such as required title, description, creator, access, and
 license fields.
+
+Plain `PublicationMetadata` is not passed directly to `client.depositions`.
+Wrap it in `ZenodoMetadata` so the Zenodo upload type and service-specific
+validation remain explicit.
 
 For Zenodo fields that are documented but not yet modeled by `ZenodoMetadata`,
 pass a raw mapping. Raw mappings are wrapped as `{"metadata": ...}` by

--- a/tests/unit/services/zenodo/test_depositions.py
+++ b/tests/unit/services/zenodo/test_depositions.py
@@ -37,6 +37,7 @@ class TestDepositionsResource(unittest.TestCase):
             message=_LEGACY_METADATA_WARNING,
             category=DeprecationWarning,
         )
+
     def test_deposition_action_url_rejects_unknown_action(self):
         with self.assertRaisesRegex(ValidationError, "unsupported deposition action"):
             deposition_action_url("https://zenodo.org", 42, "archive")

--- a/tests/unit/services/zenodo/test_depositions.py
+++ b/tests/unit/services/zenodo/test_depositions.py
@@ -31,15 +31,12 @@ class TestDepositionsResource(unittest.TestCase):
     def setUp(self):
         self._warning_context = warnings.catch_warnings()
         self._warning_context.__enter__()
+        self.addCleanup(self._warning_context.__exit__, None, None, None)
         warnings.filterwarnings(
             "ignore",
             message=_LEGACY_METADATA_WARNING,
             category=DeprecationWarning,
         )
-
-    def tearDown(self):
-        self._warning_context.__exit__(None, None, None)
-
     def test_deposition_action_url_rejects_unknown_action(self):
         with self.assertRaisesRegex(ValidationError, "unsupported deposition action"):
             deposition_action_url("https://zenodo.org", 42, "archive")

--- a/tests/unit/services/zenodo/test_depositions.py
+++ b/tests/unit/services/zenodo/test_depositions.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 from typing import Any, cast
 
 from courier.exceptions import ValidationError
@@ -9,6 +10,10 @@ from courier.services.zenodo.metadata import Creator, ZenodoMetadata
 from courier.services.zenodo.models import DepositionInfo
 
 from ._helpers import FakeResponse, FakeSession, deposition_payload
+
+_LEGACY_METADATA_WARNING = (
+    "Setting publication metadata fields directly on ZenodoMetadata is deprecated.*"
+)
 
 
 def _publication_metadata() -> PublicationMetadata:
@@ -23,6 +28,18 @@ def _publication_metadata() -> PublicationMetadata:
 
 
 class TestDepositionsResource(unittest.TestCase):
+    def setUp(self):
+        self._warning_context = warnings.catch_warnings()
+        self._warning_context.__enter__()
+        warnings.filterwarnings(
+            "ignore",
+            message=_LEGACY_METADATA_WARNING,
+            category=DeprecationWarning,
+        )
+
+    def tearDown(self):
+        self._warning_context.__exit__(None, None, None)
+
     def test_deposition_action_url_rejects_unknown_action(self):
         with self.assertRaisesRegex(ValidationError, "unsupported deposition action"):
             deposition_action_url("https://zenodo.org", 42, "archive")

--- a/tests/unit/services/zenodo/test_metadata.py
+++ b/tests/unit/services/zenodo/test_metadata.py
@@ -55,6 +55,7 @@ class TestZenodoMetadata(unittest.TestCase):
             message=_LEGACY_METADATA_WARNING,
             category=DeprecationWarning,
         )
+
     def test_software_metadata_serializes_to_zenodo_payload(self):
         md = ZenodoMetadata.software()
         md.title = "courier"

--- a/tests/unit/services/zenodo/test_metadata.py
+++ b/tests/unit/services/zenodo/test_metadata.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 from datetime import date
 
 import courier.metadata as common_metadata
@@ -12,6 +13,10 @@ from courier.services.zenodo import (
     ZenodoMetadata,
 )
 from courier.services.zenodo.metadata import _add_if_present, _person_api_name
+
+_LEGACY_METADATA_WARNING = (
+    "Setting publication metadata fields directly on ZenodoMetadata is deprecated.*"
+)
 
 
 def _valid_metadata(**overrides):
@@ -41,6 +46,18 @@ def _valid_publication_metadata(**overrides):
 
 
 class TestZenodoMetadata(unittest.TestCase):
+    def setUp(self):
+        self._warning_context = warnings.catch_warnings()
+        self._warning_context.__enter__()
+        warnings.filterwarnings(
+            "ignore",
+            message=_LEGACY_METADATA_WARNING,
+            category=DeprecationWarning,
+        )
+
+    def tearDown(self):
+        self._warning_context.__exit__(None, None, None)
+
     def test_software_metadata_serializes_to_zenodo_payload(self):
         md = ZenodoMetadata.software()
         md.title = "courier"
@@ -168,6 +185,47 @@ class TestZenodoMetadata(unittest.TestCase):
                 }
             },
         )
+
+    def test_publication_metadata_adapter_does_not_warn(self):
+        publication = _valid_publication_metadata()
+        md = ZenodoMetadata.software(publication)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            payload = md.to_payload()
+
+        deprecations = [
+            warning
+            for warning in caught
+            if issubclass(warning.category, DeprecationWarning)
+        ]
+        self.assertEqual(deprecations, [])
+        self.assertEqual(payload["metadata"]["title"], "courier")
+
+    def test_legacy_common_metadata_serialization_warns(self):
+        md = _valid_metadata()
+
+        with self.assertWarnsRegex(DeprecationWarning, "PublicationMetadata"):
+            payload = md.to_api_dict()
+
+        self.assertEqual(payload["title"], "courier")
+
+    def test_legacy_common_metadata_helper_methods_warn(self):
+        md = ZenodoMetadata.dataset()
+
+        with self.assertWarnsRegex(DeprecationWarning, "PublicationMetadata"):
+            creator = md.add_creator(name="Doe, Jane")
+        with self.assertWarnsRegex(DeprecationWarning, "PublicationMetadata"):
+            md.add_keyword("data")
+        with self.assertWarnsRegex(DeprecationWarning, "PublicationMetadata"):
+            related = md.add_related_identifier(
+                identifier="10.1234/example",
+                relation="cites",
+            )
+
+        self.assertIs(md.creators[0], creator)
+        self.assertEqual(md.keywords, ["data"])
+        self.assertIs(md.related_identifiers[0], related)
 
     def test_publication_metadata_keeps_zenodo_specific_fields_on_adapter(self):
         publication = _valid_publication_metadata()

--- a/tests/unit/services/zenodo/test_metadata.py
+++ b/tests/unit/services/zenodo/test_metadata.py
@@ -49,15 +49,12 @@ class TestZenodoMetadata(unittest.TestCase):
     def setUp(self):
         self._warning_context = warnings.catch_warnings()
         self._warning_context.__enter__()
+        self.addCleanup(self._warning_context.__exit__, None, None, None)
         warnings.filterwarnings(
             "ignore",
             message=_LEGACY_METADATA_WARNING,
             category=DeprecationWarning,
         )
-
-    def tearDown(self):
-        self._warning_context.__exit__(None, None, None)
-
     def test_software_metadata_serializes_to_zenodo_payload(self):
         md = ZenodoMetadata.software()
         md.title = "courier"

--- a/tests/unit/test_tests.py
+++ b/tests/unit/test_tests.py
@@ -4,6 +4,7 @@ from importlib.metadata import PackageNotFoundError
 from unittest import mock
 
 import courier
+import courier.metadata as metadata_models
 
 
 class TestVersion(unittest.TestCase):
@@ -28,3 +29,11 @@ class TestVersion(unittest.TestCase):
 
         self.assertEqual(reloaded.__version__, "0.0.0+unknown")
         importlib.reload(courier)
+
+
+class TestPublicApi(unittest.TestCase):
+    def test_publication_metadata_models_are_top_level_imports(self):
+        self.assertIs(courier.Contributor, metadata_models.Contributor)
+        self.assertIs(courier.Person, metadata_models.Person)
+        self.assertIs(courier.PublicationMetadata, metadata_models.PublicationMetadata)
+        self.assertIs(courier.RelatedIdentifier, metadata_models.RelatedIdentifier)


### PR DESCRIPTION
This PR makes `PublicationMetadata` the preferred public metadata authoring API and marks direct publication-field  authoring on `ZenodoMetadata` as deprecated. The legacy Zenodo path still works for migration, but now emits `DeprecationWarning` when consumed or when legacy helper mutators are used.

## Summary
- Re-exported common metadata models from courier:
  - `PublicationMetadata`
  - `Person`
  - `Contributor`
  - `RelatedIdentifier`
- Added tests documenting the intended top-level public import API.
- Added deprecation warnings for legacy direct publication metadata authoring on `ZenodoMetadata`.
- Deprecated legacy helper mutators:
  - `ZenodoMetadata.add_creator()`
  - `ZenodoMetadata.add_keyword()`
  - `ZenodoMetadata.add_related_identifier()`
- Kept Zenodo-specific helpers such as communities and grants unchanged.
- Kept `ZenodoMetadata.from_dict()` and raw mapping support unchanged.
- Updated `README` examples to prefer `PublicationMetadata` wrapped by `ZenodoMetadata`.

## Examples
Preferred:
```py
from courier import Person, PublicationMetadata
from courier.services.zenodo import ZenodoMetadata

publication = PublicationMetadata(
  title="courier Zenodo sandbox demo",
  description="Small demonstration upload created with courier.",
  creators=[Person(name="Doe, Jane")],
  license="cc-by-4.0",
)

metadata = ZenodoMetadata.software(publication)
```
Deprecated but temporarily supported:
```py
from courier.services.zenodo import Creator, ZenodoMetadata

metadata = ZenodoMetadata.software()
metadata.title = "courier Zenodo sandbox demo"
metadata.description = "Small demonstration upload created with courier."
metadata.license = "cc-by-4.0"
metadata.creators.append(Creator(name="Doe, Jane"))
```

## Validation
Validated with:
```sh
ruff check --fix --diff .
python -m mypy courier
pytest -q
coverage run -m pytest -q
coverage combine
coverage report -m
pytest -q tests/integration/test_readme.py
```