### PR TITLE
Document publication metadata service boundary

### DIFF
--- a/courier/metadata.py
+++ b/courier/metadata.py
@@ -1,4 +1,9 @@
-"""Service-independent publication metadata models."""
+"""Service-independent publication metadata models.
+
+This module defines courier's reusable publication metadata vocabulary. It must
+not import service-specific clients or adapters; publication services should
+adapt these models into their own API payloads.
+"""
 
 from __future__ import annotations
 

--- a/tests/unit/test_publication_metadata_boundary.py
+++ b/tests/unit/test_publication_metadata_boundary.py
@@ -72,8 +72,13 @@ class TestPublicationMetadataBoundary(unittest.TestCase):
 def _imported_modules(node: ast.AST) -> tuple[str, ...]:
     if isinstance(node, ast.Import):
         return tuple(alias.name for alias in node.names)
-    if isinstance(node, ast.ImportFrom) and node.module:
-        return (node.module,)
+    if isinstance(node, ast.ImportFrom):
+        if node.level:
+            if node.module:
+                return (f"courier.{node.module}",)
+            return tuple(f"courier.{alias.name}" for alias in node.names)
+        if node.module:
+            return (node.module,)
     return ()
 
 

--- a/tests/unit/test_publication_metadata_boundary.py
+++ b/tests/unit/test_publication_metadata_boundary.py
@@ -1,0 +1,81 @@
+import ast
+import unittest
+from pathlib import Path
+from typing import Any
+
+from courier import Person, PublicationMetadata
+
+
+def _generic_repository_payload(metadata: PublicationMetadata) -> dict[str, Any]:
+    """Test-only adapter proving PublicationMetadata is not Zenodo-specific."""
+    return {
+        "name": metadata.title,
+        "summary": metadata.description,
+        "released": (
+            metadata.publication_date.isoformat() if metadata.publication_date else None
+        ),
+        "authors": [_person_label(person) for person in metadata.creators],
+        "tags": list(metadata.keywords),
+        "license_id": metadata.license,
+    }
+
+
+def _person_label(person: Person) -> str:
+    if person.name:
+        return person.name
+    return f"{person.given_names} {person.family_name}"
+
+
+class TestPublicationMetadataBoundary(unittest.TestCase):
+    def test_publication_metadata_can_feed_non_zenodo_adapter(self):
+        metadata = PublicationMetadata(
+            title="Reusable dataset",
+            description="Dataset shared across publication services.",
+            publication_date="2026-05-29",
+            creators=[
+                Person(family_name="Doe", given_names="Jane"),
+                Person(name="Smith, Chris"),
+            ],
+            keywords=["dataset", "workflow"],
+            license="MIT",
+        )
+
+        payload = _generic_repository_payload(metadata)
+
+        self.assertEqual(
+            payload,
+            {
+                "name": "Reusable dataset",
+                "summary": "Dataset shared across publication services.",
+                "released": "2026-05-29",
+                "authors": ["Jane Doe", "Smith, Chris"],
+                "tags": ["dataset", "workflow"],
+                "license_id": "MIT",
+            },
+        )
+
+    def test_common_metadata_module_has_no_service_imports(self):
+        tree = ast.parse(Path("courier/metadata.py").read_text(encoding="utf-8"))
+
+        imported_modules = {
+            module_name
+            for node in ast.walk(tree)
+            for module_name in _imported_modules(node)
+        }
+
+        self.assertFalse(
+            any(module.startswith("courier.services") for module in imported_modules),
+            imported_modules,
+        )
+
+
+def _imported_modules(node: ast.AST) -> tuple[str, ...]:
+    if isinstance(node, ast.Import):
+        return tuple(alias.name for alias in node.names)
+    if isinstance(node, ast.ImportFrom) and node.module:
+        return (node.module,)
+    return ()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR makes the service-independent boundary of `PublicationMetadata` explicit. It documents that `courier.metadata` defines reusable publication metadata only, and adds tests showing that another publication-service adapter can consume `PublicationMetadata` without importing or depending on Zenodo code.

## Summary
- Expanded the `courier.metadata` module docstring to state the service boundary.
- Added a test-only non-Zenodo adapter that consumes `PublicationMetadata`.
- Verified common metadata can be transformed into another platform-style payload.
- Added an AST-based import-boundary test confirming `courier.metadata` does not import from `courier.services`.
- Did not add a real second service, abstract adapter class, or speculative metadata fields.

## Example
The tested boundary is equivalent to a future service doing something like:
```py
from courier import PublicationMetadata

def platform_payload(metadata: PublicationMetadata) -> dict[str, object]:
  return {
    "name": metadata.title,
    "summary": metadata.description,
    "tags": list(metadata.keywords),
  }
```
No Zenodo imports are needed.

## Validation
Validated with:
```sh
ruff check --fix --diff .
python -m mypy courier
pytest -q
coverage run -m pytest -q
coverage combine
coverage report -m
```