### PR TITLE
Internal CKAN Substrate

### DIFF
--- a/courier/services/ckan/__init__.py
+++ b/courier/services/ckan/__init__.py
@@ -1,0 +1,5 @@
+"""Internal CKAN substrate for service-specific clients."""
+
+from courier.services.ckan.exceptions import CkanApiError
+
+__all__ = ["CkanApiError"]

--- a/courier/services/ckan/__init__.py
+++ b/courier/services/ckan/__init__.py
@@ -1,5 +1,6 @@
 """Internal CKAN substrate for service-specific clients."""
 
+from courier.services.ckan.client import CkanClient
 from courier.services.ckan.exceptions import CkanApiError
 
-__all__ = ["CkanApiError"]
+__all__ = ["CkanApiError", "CkanClient"]

--- a/courier/services/ckan/actions.py
+++ b/courier/services/ckan/actions.py
@@ -1,0 +1,43 @@
+"""CKAN Action API access."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from courier.services.ckan.response import read_ckan_result
+from courier.transport.url import join_url, quote_path_segment
+
+if TYPE_CHECKING:
+    from courier.services.ckan.client import CkanClient
+
+
+def action_url(base_url: str, action: str) -> str:
+    """Build the URL for a CKAN action endpoint."""
+    return join_url(
+        base_url,
+        segments=[
+            "api",
+            "3",
+            "action",
+            quote_path_segment(action, field_name="action"),
+        ],
+    )
+
+
+@dataclass
+class ActionsResource:
+    """Low-level CKAN Action API wrapper."""
+
+    client: CkanClient
+
+    def call(self, action: str, data: Mapping[str, Any] | None = None) -> Any:
+        """Call a CKAN action and return its unwrapped result."""
+        payload = dict(data) if data is not None else {}
+        resp = self.client.request(
+            "POST",
+            action_url(self.client.base_url, action),
+            json=payload,
+        )
+        return read_ckan_result(resp)

--- a/courier/services/ckan/client.py
+++ b/courier/services/ckan/client.py
@@ -1,0 +1,47 @@
+"""Internal CKAN client."""
+
+from __future__ import annotations
+
+import requests
+
+from courier.http_client import HttpClient
+from courier.services.ckan.actions import ActionsResource
+
+
+class CkanClient(HttpClient):
+    """Small internal client for CKAN-backed service adapters."""
+
+    def __init__(
+        self,
+        address: str,
+        *,
+        api_token: str | None = None,
+        default_scheme: str = "https",
+        verify: bool | str = True,
+        timeout: float | tuple[float, float] = 30.0,
+        session: requests.Session | None = None,
+    ) -> None:
+        super().__init__(
+            address,
+            token=None,
+            default_scheme=default_scheme,
+            verify=verify,
+            timeout=timeout,
+            session=session,
+        )
+        self._api_token: str | None = None
+        self.api_token = api_token
+        self.action = ActionsResource(self)
+
+    @property
+    def api_token(self) -> str | None:
+        """Return the current raw CKAN API token, if any."""
+        return self._api_token
+
+    @api_token.setter
+    def api_token(self, api_token: str | None) -> None:
+        """Set the raw CKAN API token and synchronize the Authorization header."""
+        self._api_token = self._normalize_token(api_token)
+        self.session.headers.pop("Authorization", None)
+        if self._api_token is not None:
+            self.session.headers["Authorization"] = self._api_token

--- a/courier/services/ckan/client.py
+++ b/courier/services/ckan/client.py
@@ -6,6 +6,8 @@ import requests
 
 from courier.http_client import HttpClient
 from courier.services.ckan.actions import ActionsResource
+from courier.services.ckan.packages import PackagesResource
+from courier.services.ckan.resources import ResourcesResource
 
 
 class CkanClient(HttpClient):
@@ -32,6 +34,8 @@ class CkanClient(HttpClient):
         self._api_token: str | None = None
         self.api_token = api_token
         self.action = ActionsResource(self)
+        self.packages = PackagesResource(self)
+        self.resources = ResourcesResource(self)
 
     @property
     def api_token(self) -> str | None:

--- a/courier/services/ckan/exceptions.py
+++ b/courier/services/ckan/exceptions.py
@@ -1,0 +1,7 @@
+"""CKAN-specific exceptions."""
+
+from courier.exceptions import HttpError
+
+
+class CkanApiError(HttpError):
+    """Raised when a CKAN action response fails or is malformed."""

--- a/courier/services/ckan/packages.py
+++ b/courier/services/ckan/packages.py
@@ -1,0 +1,16 @@
+"""CKAN package resource skeleton."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from courier.services.ckan.client import CkanClient
+
+
+@dataclass
+class PackagesResource:
+    """Namespace for CKAN package actions."""
+
+    client: CkanClient

--- a/courier/services/ckan/resources.py
+++ b/courier/services/ckan/resources.py
@@ -1,0 +1,16 @@
+"""CKAN resource skeleton."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from courier.services.ckan.client import CkanClient
+
+
+@dataclass
+class ResourcesResource:
+    """Namespace for CKAN resource actions."""
+
+    client: CkanClient

--- a/courier/services/ckan/response.py
+++ b/courier/services/ckan/response.py
@@ -1,0 +1,98 @@
+"""CKAN action response handling."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, NoReturn
+
+import requests
+
+from courier.services.ckan.exceptions import CkanApiError
+
+
+def read_ckan_result(resp: requests.Response) -> Any:
+    """Decode and unwrap a CKAN action response."""
+    if resp.status_code >= 400:
+        raise_ckan_error(resp)
+
+    payload = _response_payload(resp)
+    if not isinstance(payload, Mapping):
+        raise CkanApiError(
+            method=_response_method(resp),
+            url=resp.url,
+            status_code=resp.status_code,
+            message="CKAN action response must be a JSON object.",
+            response_text=getattr(resp, "text", None),
+            payload=payload,
+        )
+
+    if payload.get("success") is not True:
+        raise CkanApiError(
+            method=_response_method(resp),
+            url=resp.url,
+            status_code=resp.status_code,
+            message=_error_message(payload, resp),
+            response_text=getattr(resp, "text", None),
+            payload=dict(payload),
+        )
+
+    if "result" not in payload:
+        raise CkanApiError(
+            method=_response_method(resp),
+            url=resp.url,
+            status_code=resp.status_code,
+            message="CKAN action response must include a result field.",
+            response_text=getattr(resp, "text", None),
+            payload=dict(payload),
+        )
+
+    return payload["result"]
+
+
+def raise_ckan_error(resp: requests.Response) -> NoReturn:
+    """Raise an exception that preserves CKAN's structured error payload."""
+    payload = _response_payload(resp)
+    raise CkanApiError(
+        method=_response_method(resp),
+        url=resp.url,
+        status_code=resp.status_code,
+        message=_error_message(payload, resp),
+        response_text=getattr(resp, "text", None),
+        payload=payload,
+    )
+
+
+def _response_method(resp: requests.Response) -> str:
+    request = getattr(resp, "request", None)
+    method = getattr(request, "method", None)
+    return method or "HTTP"
+
+
+def _response_payload(resp: requests.Response) -> Any | None:
+    try:
+        return resp.json()
+    except ValueError:
+        return None
+
+
+def _error_message(payload: Any | None, resp: requests.Response) -> str:
+    if isinstance(payload, Mapping):
+        error = payload.get("error")
+        if isinstance(error, Mapping):
+            message = error.get("message") or error.get("__type")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+        elif isinstance(error, str) and error.strip():
+            return error.strip()
+
+        message = payload.get("message")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+
+        if payload.get("success") is not True:
+            return "CKAN action failed."
+
+    text = getattr(resp, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text.strip()
+    return "CKAN API request failed."

--- a/tests/unit/services/ckan/__init__.py
+++ b/tests/unit/services/ckan/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the internal CKAN substrate."""

--- a/tests/unit/services/ckan/_helpers.py
+++ b/tests/unit/services/ckan/_helpers.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+
+class FakeRequest:
+    def __init__(self, method: str):
+        self.method = method
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        *,
+        url: str = "https://ckan.test/api/3/action/package_show",
+        status_code: int = 200,
+        text: str = "ok",
+        json_value: Any = None,
+        json_exc: Exception | None = None,
+        request: FakeRequest | None = None,
+    ):
+        self.url = url
+        self.status_code = status_code
+        self.text = text
+        self._json_value = json_value
+        self._json_exc = json_exc
+        self.request = request
+
+    def json(self) -> Any:
+        if self._json_exc is not None:
+            raise self._json_exc
+        return self._json_value

--- a/tests/unit/services/ckan/_helpers.py
+++ b/tests/unit/services/ckan/_helpers.py
@@ -28,3 +28,17 @@ class FakeResponse:
         if self._json_exc is not None:
             raise self._json_exc
         return self._json_value
+
+
+class FakeSession:
+    def __init__(self, responses: list[FakeResponse] | None = None):
+        self.headers: dict[str, str] = {}
+        self.calls: list[dict[str, Any]] = []
+        self.responses = list(responses or [FakeResponse()])
+
+    def request(self, method: str, url: str, **kwargs: Any) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, **kwargs})
+        response = self.responses.pop(0)
+        response.url = url
+        response.request = FakeRequest(method)
+        return response

--- a/tests/unit/services/ckan/test_client.py
+++ b/tests/unit/services/ckan/test_client.py
@@ -1,0 +1,121 @@
+import unittest
+from typing import Any, cast
+
+from courier.services.ckan import CkanClient
+
+from ._helpers import FakeResponse, FakeSession
+
+
+class TestCkanClientInit(unittest.TestCase):
+    def test_base_url_is_normalized(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+
+        self.assertEqual(client.base_url, "https://ckan.test")
+        self.assertIs(client.action.client, client)
+
+    def test_default_scheme_is_used_when_address_has_no_scheme(self):
+        client = CkanClient(
+            "ckan.test",
+            default_scheme="http",
+            session=cast(Any, FakeSession()),
+        )
+
+        self.assertEqual(client.base_url, "http://ckan.test")
+
+    def test_api_token_sets_raw_authorization_header(self):
+        session = FakeSession()
+
+        _ = CkanClient("ckan.test", api_token="abc", session=cast(Any, session))
+
+        self.assertEqual(session.headers["Authorization"], "abc")
+
+    def test_api_token_is_stripped(self):
+        session = FakeSession()
+
+        client = CkanClient(
+            "ckan.test",
+            api_token="  abc  ",
+            session=cast(Any, session),
+        )
+
+        self.assertEqual(client.api_token, "abc")
+        self.assertEqual(session.headers["Authorization"], "abc")
+
+    def test_api_token_can_be_changed(self):
+        session = FakeSession()
+        client = CkanClient("ckan.test", api_token="abc", session=cast(Any, session))
+
+        client.api_token = "def"
+
+        self.assertEqual(client.api_token, "def")
+        self.assertEqual(session.headers["Authorization"], "def")
+
+    def test_api_token_can_be_cleared(self):
+        session = FakeSession()
+        client = CkanClient("ckan.test", api_token="abc", session=cast(Any, session))
+
+        client.api_token = None
+
+        self.assertIsNone(client.api_token)
+        self.assertNotIn("Authorization", session.headers)
+
+    def test_blank_api_token_clears_header(self):
+        session = FakeSession()
+        client = CkanClient("ckan.test", api_token="abc", session=cast(Any, session))
+
+        client.api_token = "  "
+
+        self.assertIsNone(client.api_token)
+        self.assertNotIn("Authorization", session.headers)
+
+
+class TestActionsResource(unittest.TestCase):
+    def test_call_posts_to_action_endpoint_and_unwraps_result(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": {"id": "dataset"}})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        result = client.action.call("package_show", {"id": "dataset"})
+
+        self.assertEqual(result, {"id": "dataset"})
+        self.assertEqual(session.calls[0]["method"], "POST")
+        self.assertEqual(
+            session.calls[0]["url"],
+            "https://ckan.test/api/3/action/package_show",
+        )
+        self.assertEqual(session.calls[0]["json"], {"id": "dataset"})
+
+    def test_call_uses_empty_payload_when_data_is_omitted(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": []})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        result = client.action.call("package_list")
+
+        self.assertEqual(result, [])
+        self.assertEqual(session.calls[0]["json"], {})
+
+    def test_call_quotes_action_name(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": []})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        _ = client.action.call("weird action")
+
+        self.assertEqual(
+            session.calls[0]["url"],
+            "https://ckan.test/api/3/action/weird%20action",
+        )
+
+    def test_call_rejects_blank_action_name(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+
+        with self.assertRaisesRegex(ValueError, "action must be non-empty"):
+            client.action.call(" ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/ckan/test_client.py
+++ b/tests/unit/services/ckan/test_client.py
@@ -12,6 +12,8 @@ class TestCkanClientInit(unittest.TestCase):
 
         self.assertEqual(client.base_url, "https://ckan.test")
         self.assertIs(client.action.client, client)
+        self.assertIs(client.packages.client, client)
+        self.assertIs(client.resources.client, client)
 
     def test_default_scheme_is_used_when_address_has_no_scheme(self):
         client = CkanClient(

--- a/tests/unit/services/ckan/test_response.py
+++ b/tests/unit/services/ckan/test_response.py
@@ -1,0 +1,120 @@
+import json
+import unittest
+from typing import Any, cast
+
+from courier.services.ckan.exceptions import CkanApiError
+from courier.services.ckan.response import read_ckan_result
+
+from ._helpers import FakeRequest, FakeResponse
+
+
+class TestCkanResponse(unittest.TestCase):
+    def test_successful_action_result_is_unwrapped(self):
+        response = FakeResponse(
+            json_value={"success": True, "result": {"name": "dataset"}}
+        )
+
+        result = read_ckan_result(cast(Any, response))
+
+        self.assertEqual(result, {"name": "dataset"})
+
+    def test_successful_none_result_is_preserved(self):
+        response = FakeResponse(json_value={"success": True, "result": None})
+
+        self.assertIsNone(read_ckan_result(cast(Any, response)))
+
+    def test_invalid_json_is_wrapped(self):
+        response = FakeResponse(json_exc=ValueError("invalid json"))
+
+        with self.assertRaises(CkanApiError) as ctx:
+            read_ckan_result(cast(Any, response))
+
+        self.assertEqual(
+            ctx.exception.message,
+            "CKAN action response must be a JSON object.",
+        )
+        self.assertEqual(ctx.exception.method, "HTTP")
+
+    def test_non_mapping_payload_is_rejected(self):
+        response = FakeResponse(json_value=[{"success": True}])
+
+        with self.assertRaisesRegex(CkanApiError, "JSON object"):
+            read_ckan_result(cast(Any, response))
+
+    def test_missing_success_is_rejected(self):
+        response = FakeResponse(json_value={"result": {"name": "dataset"}})
+
+        with self.assertRaises(CkanApiError) as ctx:
+            read_ckan_result(cast(Any, response))
+
+        self.assertEqual(ctx.exception.message, "CKAN action failed.")
+
+    def test_missing_result_is_rejected(self):
+        response = FakeResponse(json_value={"success": True})
+
+        with self.assertRaises(CkanApiError) as ctx:
+            read_ckan_result(cast(Any, response))
+
+        self.assertEqual(
+            ctx.exception.message,
+            "CKAN action response must include a result field.",
+        )
+
+    def test_failed_action_uses_structured_error_message(self):
+        payload = {
+            "success": False,
+            "error": {"message": "Dataset not found", "__type": "Not Found Error"},
+        }
+        response = FakeResponse(
+            text=json.dumps(payload),
+            json_value=payload,
+            request=FakeRequest("POST"),
+        )
+
+        with self.assertRaises(CkanApiError) as ctx:
+            read_ckan_result(cast(Any, response))
+
+        self.assertEqual(ctx.exception.message, "Dataset not found")
+        self.assertEqual(ctx.exception.method, "POST")
+        self.assertEqual(ctx.exception.payload, payload)
+
+    def test_failed_action_falls_back_to_error_type(self):
+        response = FakeResponse(
+            json_value={"success": False, "error": {"__type": "Validation Error"}}
+        )
+
+        with self.assertRaises(CkanApiError) as ctx:
+            read_ckan_result(cast(Any, response))
+
+        self.assertEqual(ctx.exception.message, "Validation Error")
+
+    def test_http_error_uses_response_text_when_payload_is_not_json(self):
+        response = FakeResponse(
+            status_code=500,
+            text="Server unavailable",
+            json_exc=ValueError("invalid json"),
+            request=FakeRequest("GET"),
+        )
+
+        with self.assertRaises(CkanApiError) as ctx:
+            read_ckan_result(cast(Any, response))
+
+        self.assertEqual(ctx.exception.message, "Server unavailable")
+        self.assertEqual(ctx.exception.status_code, 500)
+        self.assertIsNone(ctx.exception.payload)
+
+    def test_http_error_without_payload_or_text_uses_default_message(self):
+        response = FakeResponse(
+            status_code=500,
+            text=" ",
+            json_exc=ValueError("invalid json"),
+        )
+
+        with self.assertRaises(CkanApiError) as ctx:
+            read_ckan_result(cast(Any, response))
+
+        self.assertEqual(ctx.exception.message, "CKAN API request failed.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/ckan/test_response.py
+++ b/tests/unit/services/ckan/test_response.py
@@ -88,6 +88,26 @@ class TestCkanResponse(unittest.TestCase):
 
         self.assertEqual(ctx.exception.message, "Validation Error")
 
+    def test_failed_action_uses_string_error(self):
+        response = FakeResponse(
+            json_value={"success": False, "error": "Dataset not found"}
+        )
+
+        with self.assertRaises(CkanApiError) as ctx:
+            read_ckan_result(cast(Any, response))
+
+        self.assertEqual(ctx.exception.message, "Dataset not found")
+
+    def test_failed_action_uses_top_level_message(self):
+        response = FakeResponse(
+            json_value={"success": False, "message": "Dataset not found"}
+        )
+
+        with self.assertRaises(CkanApiError) as ctx:
+            read_ckan_result(cast(Any, response))
+
+        self.assertEqual(ctx.exception.message, "Dataset not found")
+
     def test_http_error_uses_response_text_when_payload_is_not_json(self):
         response = FakeResponse(
             status_code=500,


### PR DESCRIPTION
This pull request introduces the internal CKAN transport and response layer required by the Dataportal client. It deliberately keeps the CKAN integration internal so courier does not commit to a public generic CKAN API before that abstraction has proven useful beyond the Dataportal service.

## Summary

- Added internal `courier.services.ckan` and `CkanClient`.
- Added raw CKAN token handling through `Authorization: <token>`.
- Added `/api/3/action/{action}` URL construction and `client.action.call(...)`.
- Added strict action-response validation and structured `CkanApiError` payloads.
- Added package and resource namespaces as the foundation for later operations.
- Kept the CKAN client out of the top-level `courier` exports.
- Commits: `4c454f6 Add internal CKAN response handling`, `861a0aa Add CKAN client and action calls`, and `74a3559 Add CKAN package and resource skeletons`.

## Example

```python
from courier.services.ckan import CkanClient

client = CkanClient("https://ckan.example.org", api_token="secret")
package = client.action.call("package_show", {"id": "dataset-name"})
```

## Unit tests

- Action URL construction.
- Raw token header insertion, replacement, and removal.
- Successful CKAN response unwrapping.
- Failed, malformed, and incomplete CKAN responses.
- Package and resource namespace construction.

## Validation

- `black`
- `ruff check`
- `pytest`
- `mypy`