### PR TITLE
CKAN Package And Resource Operations

### DIFF
--- a/courier/services/ckan/actions.py
+++ b/courier/services/ckan/actions.py
@@ -32,12 +32,23 @@ class ActionsResource:
 
     client: CkanClient
 
-    def call(self, action: str, data: Mapping[str, Any] | None = None) -> Any:
+    def call(
+        self,
+        action: str,
+        data: Mapping[str, Any] | None = None,
+        *,
+        files: dict[str, Any] | None = None,
+    ) -> Any:
         """Call a CKAN action and return its unwrapped result."""
         payload = dict(data) if data is not None else {}
+        request_kwargs: dict[str, Any]
+        if files is None:
+            request_kwargs = {"json": payload}
+        else:
+            request_kwargs = {"data": payload, "files": files}
         resp = self.client.request(
             "POST",
             action_url(self.client.base_url, action),
-            json=payload,
+            **request_kwargs,
         )
         return read_ckan_result(resp)

--- a/courier/services/ckan/models.py
+++ b/courier/services/ckan/models.py
@@ -1,0 +1,90 @@
+"""Small CKAN response models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+
+@dataclass(frozen=True)
+class CkanResourceInfo:
+    """Important fields returned by CKAN resource actions."""
+
+    id: str
+    name: str | None
+    package_id: str | None
+    url: str | None
+    format: str | None
+    mimetype: str | None
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CkanResourceInfo:
+        return cls(
+            id=str(data["id"]),
+            name=_optional_string(data.get("name")),
+            package_id=_optional_string(data.get("package_id")),
+            url=_optional_string(data.get("url")),
+            format=_optional_string(data.get("format")),
+            mimetype=_optional_string(data.get("mimetype")),
+            raw=dict(data),
+        )
+
+
+@dataclass(frozen=True)
+class CkanPackageInfo:
+    """Important fields returned by CKAN package actions."""
+
+    id: str
+    name: str
+    title: str | None
+    resources: list[CkanResourceInfo]
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CkanPackageInfo:
+        raw_resources = data.get("resources")
+        resources = (
+            cast(list[Any], raw_resources) if isinstance(raw_resources, list) else []
+        )
+        return cls(
+            id=str(data["id"]),
+            name=str(data["name"]),
+            title=_optional_string(data.get("title")),
+            resources=[
+                CkanResourceInfo.from_dict(item)
+                for item in resources
+                if isinstance(item, dict) and "id" in item
+            ],
+            raw=dict(data),
+        )
+
+
+@dataclass(frozen=True)
+class CkanPackageSearchResult:
+    """Parsed CKAN package search response."""
+
+    count: int
+    results: list[CkanPackageInfo]
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CkanPackageSearchResult:
+        raw_results = data.get("results")
+        results = cast(list[Any], raw_results) if isinstance(raw_results, list) else []
+        return cls(
+            count=int(data.get("count", 0)),
+            results=[
+                CkanPackageInfo.from_dict(item)
+                for item in results
+                if isinstance(item, dict) and "id" in item and "name" in item
+            ],
+            raw=dict(data),
+        )
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/courier/services/ckan/packages.py
+++ b/courier/services/ckan/packages.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from courier.exceptions import ValidationError
+from courier.services.ckan.models import CkanPackageInfo, CkanPackageSearchResult
 
 if TYPE_CHECKING:
     from courier.services.ckan.client import CkanClient
@@ -11,6 +15,55 @@ if TYPE_CHECKING:
 
 @dataclass
 class PackagesResource:
-    """Namespace for CKAN package actions."""
+    """CKAN package actions."""
 
     client: CkanClient
+
+    def create(self, payload: Mapping[str, Any]) -> CkanPackageInfo:
+        """Create a CKAN package."""
+        return CkanPackageInfo.from_dict(
+            self.client.action.call("package_create", payload)
+        )
+
+    def show(self, package: str | CkanPackageInfo) -> CkanPackageInfo:
+        """Show a CKAN package by id, name, or package model."""
+        result = self.client.action.call("package_show", {"id": _package_id(package)})
+        return CkanPackageInfo.from_dict(result)
+
+    def search(
+        self,
+        query: str | None = None,
+        **filters: Any,
+    ) -> CkanPackageSearchResult:
+        """Search CKAN packages."""
+        payload = dict(filters)
+        if query is not None:
+            payload["q"] = query
+        return CkanPackageSearchResult.from_dict(
+            self.client.action.call("package_search", payload)
+        )
+
+    def patch(
+        self,
+        package: str | CkanPackageInfo,
+        payload: Mapping[str, Any],
+    ) -> CkanPackageInfo:
+        """Partially update a CKAN package."""
+        data = dict(payload)
+        data["id"] = _package_id(package)
+        return CkanPackageInfo.from_dict(
+            self.client.action.call("package_patch", data)
+        )
+
+    def delete(self, package: str | CkanPackageInfo) -> None:
+        """Delete a CKAN package."""
+        _ = self.client.action.call("package_delete", {"id": _package_id(package)})
+
+
+def _package_id(package: str | CkanPackageInfo) -> str:
+    if isinstance(package, CkanPackageInfo):
+        return package.id
+    text = str(package).strip()
+    if not text:
+        raise ValidationError("package id must be non-empty")
+    return text

--- a/courier/services/ckan/packages.py
+++ b/courier/services/ckan/packages.py
@@ -51,9 +51,7 @@ class PackagesResource:
         """Partially update a CKAN package."""
         data = dict(payload)
         data["id"] = _package_id(package)
-        return CkanPackageInfo.from_dict(
-            self.client.action.call("package_patch", data)
-        )
+        return CkanPackageInfo.from_dict(self.client.action.call("package_patch", data))
 
     def delete(self, package: str | CkanPackageInfo) -> None:
         """Delete a CKAN package."""

--- a/courier/services/ckan/packages.py
+++ b/courier/services/ckan/packages.py
@@ -59,9 +59,8 @@ class PackagesResource:
 
 
 def _package_id(package: str | CkanPackageInfo) -> str:
-    if isinstance(package, CkanPackageInfo):
-        return package.id
-    text = str(package).strip()
+    value = package.id if isinstance(package, CkanPackageInfo) else package
+    text = str(value).strip()
     if not text:
         raise ValidationError("package id must be non-empty")
     return text

--- a/courier/services/ckan/resources.py
+++ b/courier/services/ckan/resources.py
@@ -37,7 +37,9 @@ class ResourcesResource:
 
     def show(self, resource: str | CkanResourceInfo) -> CkanResourceInfo:
         """Show a CKAN resource by id or resource model."""
-        result = self.client.action.call("resource_show", {"id": _resource_id(resource)})
+        result = self.client.action.call(
+            "resource_show", {"id": _resource_id(resource)}
+        )
         return CkanResourceInfo.from_dict(result)
 
     def patch(

--- a/courier/services/ckan/resources.py
+++ b/courier/services/ckan/resources.py
@@ -84,9 +84,8 @@ class ResourcesResource:
 
 
 def _resource_id(resource: str | CkanResourceInfo) -> str:
-    if isinstance(resource, CkanResourceInfo):
-        return resource.id
-    text = str(resource).strip()
+    value = resource.id if isinstance(resource, CkanResourceInfo) else resource
+    text = str(value).strip()
     if not text:
         raise ValidationError("resource id must be non-empty")
     return text

--- a/courier/services/ckan/resources.py
+++ b/courier/services/ckan/resources.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from courier.exceptions import ValidationError
+from courier.services.ckan.models import CkanResourceInfo
 
 if TYPE_CHECKING:
     from courier.services.ckan.client import CkanClient
@@ -11,6 +15,42 @@ if TYPE_CHECKING:
 
 @dataclass
 class ResourcesResource:
-    """Namespace for CKAN resource actions."""
+    """CKAN resource actions."""
 
     client: CkanClient
+
+    def create(self, payload: Mapping[str, Any]) -> CkanResourceInfo:
+        """Create a CKAN resource."""
+        return CkanResourceInfo.from_dict(
+            self.client.action.call("resource_create", payload)
+        )
+
+    def show(self, resource: str | CkanResourceInfo) -> CkanResourceInfo:
+        """Show a CKAN resource by id or resource model."""
+        result = self.client.action.call("resource_show", {"id": _resource_id(resource)})
+        return CkanResourceInfo.from_dict(result)
+
+    def patch(
+        self,
+        resource: str | CkanResourceInfo,
+        payload: Mapping[str, Any],
+    ) -> CkanResourceInfo:
+        """Partially update a CKAN resource."""
+        data = dict(payload)
+        data["id"] = _resource_id(resource)
+        return CkanResourceInfo.from_dict(
+            self.client.action.call("resource_patch", data)
+        )
+
+    def delete(self, resource: str | CkanResourceInfo) -> None:
+        """Delete a CKAN resource."""
+        _ = self.client.action.call("resource_delete", {"id": _resource_id(resource)})
+
+
+def _resource_id(resource: str | CkanResourceInfo) -> str:
+    if isinstance(resource, CkanResourceInfo):
+        return resource.id
+    text = str(resource).strip()
+    if not text:
+        raise ValidationError("resource id must be non-empty")
+    return text

--- a/courier/services/ckan/resources.py
+++ b/courier/services/ckan/resources.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from courier.exceptions import ValidationError
@@ -12,6 +13,8 @@ from courier.services.ckan.models import CkanResourceInfo
 if TYPE_CHECKING:
     from courier.services.ckan.client import CkanClient
 
+UploadPath = str | Path
+
 
 @dataclass
 class ResourcesResource:
@@ -19,8 +22,15 @@ class ResourcesResource:
 
     client: CkanClient
 
-    def create(self, payload: Mapping[str, Any]) -> CkanResourceInfo:
+    def create(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        upload: UploadPath | None = None,
+    ) -> CkanResourceInfo:
         """Create a CKAN resource."""
+        if upload is not None:
+            return self._create_with_upload(payload, upload)
         return CkanResourceInfo.from_dict(
             self.client.action.call("resource_create", payload)
         )
@@ -45,6 +55,30 @@ class ResourcesResource:
     def delete(self, resource: str | CkanResourceInfo) -> None:
         """Delete a CKAN resource."""
         _ = self.client.action.call("resource_delete", {"id": _resource_id(resource)})
+
+    def _create_with_upload(
+        self,
+        payload: Mapping[str, Any],
+        upload: UploadPath,
+    ) -> CkanResourceInfo:
+        data = dict(payload)
+        if "upload" in data:
+            raise ValidationError(
+                "payload must not include an upload field when upload is provided"
+            )
+
+        path = Path(upload)
+        filename = path.name.strip()
+        if not filename:
+            raise ValidationError("upload filename must be non-empty")
+
+        with path.open("rb") as file:
+            result = self.client.action.call(
+                "resource_create",
+                data,
+                files={"upload": (filename, file)},
+            )
+        return CkanResourceInfo.from_dict(result)
 
 
 def _resource_id(resource: str | CkanResourceInfo) -> str:

--- a/tests/unit/services/ckan/test_client.py
+++ b/tests/unit/services/ckan/test_client.py
@@ -118,6 +118,26 @@ class TestActionsResource(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "action must be non-empty"):
             client.action.call(" ")
 
+    def test_call_uses_multipart_request_when_files_are_provided(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": {"id": "res-1"}})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        result = client.action.call(
+            "resource_create",
+            {"package_id": "pkg-1"},
+            files={"upload": ("data.ttl", b"content")},
+        )
+
+        self.assertEqual(result, {"id": "res-1"})
+        self.assertEqual(session.calls[0]["data"], {"package_id": "pkg-1"})
+        self.assertEqual(
+            session.calls[0]["files"],
+            {"upload": ("data.ttl", b"content")},
+        )
+        self.assertIsNone(session.calls[0]["json"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/services/ckan/test_packages.py
+++ b/tests/unit/services/ckan/test_packages.py
@@ -1,0 +1,171 @@
+import unittest
+from typing import Any, cast
+
+from courier.exceptions import ValidationError
+from courier.services.ckan import CkanClient
+from courier.services.ckan.models import CkanPackageInfo
+
+from ._helpers import FakeResponse, FakeSession
+
+
+def package_payload(
+    *,
+    package_id: str = "pkg-1",
+    name: str = "dataset",
+    title: str | None = "Dataset",
+) -> dict[str, Any]:
+    return {
+        "id": package_id,
+        "name": name,
+        "title": title,
+        "resources": [
+            {
+                "id": "res-1",
+                "name": "data.ttl",
+                "package_id": package_id,
+                "url": "https://example.test/data.ttl",
+                "format": "ttl",
+                "mimetype": "text/turtle",
+            }
+        ],
+        "custom": "preserved",
+    }
+
+
+class TestCkanPackageModels(unittest.TestCase):
+    def test_package_info_parses_stable_fields_and_preserves_raw_payload(self):
+        payload = package_payload()
+
+        info = CkanPackageInfo.from_dict(payload)
+
+        self.assertEqual(info.id, "pkg-1")
+        self.assertEqual(info.name, "dataset")
+        self.assertEqual(info.title, "Dataset")
+        self.assertEqual(info.raw["custom"], "preserved")
+        self.assertEqual(info.resources[0].id, "res-1")
+        self.assertEqual(info.resources[0].format, "ttl")
+
+
+class TestPackagesResource(unittest.TestCase):
+    def test_create_calls_package_create_and_parses_response(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": package_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        info = client.packages.create({"name": "dataset", "title": "Dataset"})
+
+        self.assertEqual(info.name, "dataset")
+        self.assertEqual(session.calls[0]["method"], "POST")
+        self.assertEqual(
+            session.calls[0]["url"],
+            "https://ckan.test/api/3/action/package_create",
+        )
+        self.assertEqual(
+            session.calls[0]["json"],
+            {"name": "dataset", "title": "Dataset"},
+        )
+
+    def test_show_calls_package_show_with_id(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": package_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        info = client.packages.show("dataset")
+
+        self.assertEqual(info.id, "pkg-1")
+        self.assertEqual(session.calls[0]["url"], "https://ckan.test/api/3/action/package_show")
+        self.assertEqual(session.calls[0]["json"], {"id": "dataset"})
+
+    def test_show_accepts_package_model(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": package_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+        package = CkanPackageInfo.from_dict(package_payload(package_id="pkg-2"))
+
+        _ = client.packages.show(package)
+
+        self.assertEqual(session.calls[0]["json"], {"id": "pkg-2"})
+
+    def test_search_calls_package_search_with_query_and_filters(self):
+        session = FakeSession(
+            [
+                FakeResponse(
+                    json_value={
+                        "success": True,
+                        "result": {"count": 1, "results": [package_payload()]},
+                    }
+                )
+            ]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        result = client.packages.search("steel", rows=5)
+
+        self.assertEqual(result.count, 1)
+        self.assertEqual(result.results[0].name, "dataset")
+        self.assertEqual(session.calls[0]["url"], "https://ckan.test/api/3/action/package_search")
+        self.assertEqual(session.calls[0]["json"], {"rows": 5, "q": "steel"})
+
+    def test_search_without_query_uses_filters_only(self):
+        session = FakeSession(
+            [
+                FakeResponse(
+                    json_value={
+                        "success": True,
+                        "result": {"count": 0, "results": []},
+                    }
+                )
+            ]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        result = client.packages.search(rows=5)
+
+        self.assertEqual(result.count, 0)
+        self.assertEqual(session.calls[0]["json"], {"rows": 5})
+
+    def test_patch_adds_package_id_to_payload(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": package_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        info = client.packages.patch("dataset", {"title": "New title"})
+
+        self.assertEqual(info.title, "Dataset")
+        self.assertEqual(session.calls[0]["url"], "https://ckan.test/api/3/action/package_patch")
+        self.assertEqual(session.calls[0]["json"], {"title": "New title", "id": "dataset"})
+
+    def test_patch_uses_package_model_id(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": package_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+        package = CkanPackageInfo.from_dict(package_payload(package_id="pkg-2"))
+
+        _ = client.packages.patch(package, {"title": "New title"})
+
+        self.assertEqual(session.calls[0]["json"]["id"], "pkg-2")
+
+    def test_delete_calls_package_delete(self):
+        session = FakeSession([FakeResponse(json_value={"success": True, "result": None})])
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        result = client.packages.delete("dataset")
+
+        self.assertIsNone(result)
+        self.assertEqual(session.calls[0]["url"], "https://ckan.test/api/3/action/package_delete")
+        self.assertEqual(session.calls[0]["json"], {"id": "dataset"})
+
+    def test_blank_package_id_is_rejected(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+
+        with self.assertRaisesRegex(ValidationError, "package id must be non-empty"):
+            client.packages.show(" ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/ckan/test_packages.py
+++ b/tests/unit/services/ckan/test_packages.py
@@ -75,7 +75,9 @@ class TestPackagesResource(unittest.TestCase):
         info = client.packages.show("dataset")
 
         self.assertEqual(info.id, "pkg-1")
-        self.assertEqual(session.calls[0]["url"], "https://ckan.test/api/3/action/package_show")
+        self.assertEqual(
+            session.calls[0]["url"], "https://ckan.test/api/3/action/package_show"
+        )
         self.assertEqual(session.calls[0]["json"], {"id": "dataset"})
 
     def test_show_accepts_package_model(self):
@@ -106,7 +108,9 @@ class TestPackagesResource(unittest.TestCase):
 
         self.assertEqual(result.count, 1)
         self.assertEqual(result.results[0].name, "dataset")
-        self.assertEqual(session.calls[0]["url"], "https://ckan.test/api/3/action/package_search")
+        self.assertEqual(
+            session.calls[0]["url"], "https://ckan.test/api/3/action/package_search"
+        )
         self.assertEqual(session.calls[0]["json"], {"rows": 5, "q": "steel"})
 
     def test_search_without_query_uses_filters_only(self):
@@ -136,8 +140,12 @@ class TestPackagesResource(unittest.TestCase):
         info = client.packages.patch("dataset", {"title": "New title"})
 
         self.assertEqual(info.title, "Dataset")
-        self.assertEqual(session.calls[0]["url"], "https://ckan.test/api/3/action/package_patch")
-        self.assertEqual(session.calls[0]["json"], {"title": "New title", "id": "dataset"})
+        self.assertEqual(
+            session.calls[0]["url"], "https://ckan.test/api/3/action/package_patch"
+        )
+        self.assertEqual(
+            session.calls[0]["json"], {"title": "New title", "id": "dataset"}
+        )
 
     def test_patch_uses_package_model_id(self):
         session = FakeSession(
@@ -151,13 +159,17 @@ class TestPackagesResource(unittest.TestCase):
         self.assertEqual(session.calls[0]["json"]["id"], "pkg-2")
 
     def test_delete_calls_package_delete(self):
-        session = FakeSession([FakeResponse(json_value={"success": True, "result": None})])
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": None})]
+        )
         client = CkanClient("ckan.test", session=cast(Any, session))
 
         result = client.packages.delete("dataset")
 
         self.assertIsNone(result)
-        self.assertEqual(session.calls[0]["url"], "https://ckan.test/api/3/action/package_delete")
+        self.assertEqual(
+            session.calls[0]["url"], "https://ckan.test/api/3/action/package_delete"
+        )
         self.assertEqual(session.calls[0]["json"], {"id": "dataset"})
 
     def test_blank_package_id_is_rejected(self):

--- a/tests/unit/services/ckan/test_packages.py
+++ b/tests/unit/services/ckan/test_packages.py
@@ -178,6 +178,13 @@ class TestPackagesResource(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "package id must be non-empty"):
             client.packages.show(" ")
 
+    def test_blank_package_model_id_is_rejected(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+        package = CkanPackageInfo.from_dict(package_payload(package_id=" "))
+
+        with self.assertRaisesRegex(ValidationError, "package id must be non-empty"):
+            client.packages.show(package)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/services/ckan/test_resources.py
+++ b/tests/unit/services/ckan/test_resources.py
@@ -1,4 +1,6 @@
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, cast
 
 from courier.exceptions import ValidationError
@@ -65,6 +67,48 @@ class TestResourcesResource(unittest.TestCase):
                 "url": "https://example.test",
             },
         )
+
+    def test_create_with_upload_uses_multipart_request(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": resource_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "data.ttl"
+            path.write_text("@prefix x: <https://example.test/> .")
+
+            info = client.resources.create(
+                {"package_id": "pkg-1", "name": "data.ttl"},
+                upload=path,
+            )
+
+        self.assertEqual(info.id, "res-1")
+        self.assertEqual(
+            session.calls[0]["url"],
+            "https://ckan.test/api/3/action/resource_create",
+        )
+        self.assertEqual(
+            session.calls[0]["data"],
+            {"package_id": "pkg-1", "name": "data.ttl"},
+        )
+        self.assertIsNone(session.calls[0]["json"])
+        upload = session.calls[0]["files"]["upload"]
+        self.assertEqual(upload[0], "data.ttl")
+        self.assertTrue(upload[1].closed)
+
+    def test_create_with_upload_rejects_payload_upload_field(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "data.ttl"
+            path.write_text("@prefix x: <https://example.test/> .")
+
+            with self.assertRaisesRegex(ValidationError, "upload field"):
+                client.resources.create(
+                    {"package_id": "pkg-1", "upload": "not-a-file"},
+                    upload=path,
+                )
 
     def test_show_calls_resource_show_with_id(self):
         session = FakeSession(

--- a/tests/unit/services/ckan/test_resources.py
+++ b/tests/unit/services/ckan/test_resources.py
@@ -166,7 +166,9 @@ class TestResourcesResource(unittest.TestCase):
         self.assertEqual(session.calls[0]["json"]["id"], "res-2")
 
     def test_delete_calls_resource_delete(self):
-        session = FakeSession([FakeResponse(json_value={"success": True, "result": None})])
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": None})]
+        )
         client = CkanClient("ckan.test", session=cast(Any, session))
 
         result = client.resources.delete("res-1")

--- a/tests/unit/services/ckan/test_resources.py
+++ b/tests/unit/services/ckan/test_resources.py
@@ -41,6 +41,15 @@ class TestCkanResourceModels(unittest.TestCase):
         self.assertEqual(info.mimetype, "text/turtle")
         self.assertEqual(info.raw["custom"], "preserved")
 
+    def test_resource_info_accepts_missing_optional_fields(self):
+        info = CkanResourceInfo.from_dict({"id": "res-1"})
+
+        self.assertIsNone(info.name)
+        self.assertIsNone(info.package_id)
+        self.assertIsNone(info.url)
+        self.assertIsNone(info.format)
+        self.assertIsNone(info.mimetype)
+
 
 class TestResourcesResource(unittest.TestCase):
     def test_create_calls_resource_create_and_parses_response(self):
@@ -109,6 +118,15 @@ class TestResourcesResource(unittest.TestCase):
                     {"package_id": "pkg-1", "upload": "not-a-file"},
                     upload=path,
                 )
+
+    def test_create_with_upload_rejects_empty_path(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "upload filename must be non-empty",
+        ):
+            client.resources.create({"package_id": "pkg-1"}, upload="")
 
     def test_show_calls_resource_show_with_id(self):
         session = FakeSession(

--- a/tests/unit/services/ckan/test_resources.py
+++ b/tests/unit/services/ckan/test_resources.py
@@ -1,0 +1,145 @@
+import unittest
+from typing import Any, cast
+
+from courier.exceptions import ValidationError
+from courier.services.ckan import CkanClient
+from courier.services.ckan.models import CkanResourceInfo
+
+from ._helpers import FakeResponse, FakeSession
+
+
+def resource_payload(
+    *,
+    resource_id: str = "res-1",
+    package_id: str = "pkg-1",
+    name: str = "data.ttl",
+) -> dict[str, Any]:
+    return {
+        "id": resource_id,
+        "name": name,
+        "package_id": package_id,
+        "url": "https://example.test/data.ttl",
+        "format": "ttl",
+        "mimetype": "text/turtle",
+        "custom": "preserved",
+    }
+
+
+class TestCkanResourceModels(unittest.TestCase):
+    def test_resource_info_parses_stable_fields_and_preserves_raw_payload(self):
+        payload = resource_payload()
+
+        info = CkanResourceInfo.from_dict(payload)
+
+        self.assertEqual(info.id, "res-1")
+        self.assertEqual(info.name, "data.ttl")
+        self.assertEqual(info.package_id, "pkg-1")
+        self.assertEqual(info.url, "https://example.test/data.ttl")
+        self.assertEqual(info.format, "ttl")
+        self.assertEqual(info.mimetype, "text/turtle")
+        self.assertEqual(info.raw["custom"], "preserved")
+
+
+class TestResourcesResource(unittest.TestCase):
+    def test_create_calls_resource_create_and_parses_response(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": resource_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        info = client.resources.create(
+            {"package_id": "pkg-1", "name": "data.ttl", "url": "https://example.test"}
+        )
+
+        self.assertEqual(info.id, "res-1")
+        self.assertEqual(session.calls[0]["method"], "POST")
+        self.assertEqual(
+            session.calls[0]["url"],
+            "https://ckan.test/api/3/action/resource_create",
+        )
+        self.assertEqual(
+            session.calls[0]["json"],
+            {
+                "package_id": "pkg-1",
+                "name": "data.ttl",
+                "url": "https://example.test",
+            },
+        )
+
+    def test_show_calls_resource_show_with_id(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": resource_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        info = client.resources.show("res-1")
+
+        self.assertEqual(info.name, "data.ttl")
+        self.assertEqual(
+            session.calls[0]["url"],
+            "https://ckan.test/api/3/action/resource_show",
+        )
+        self.assertEqual(session.calls[0]["json"], {"id": "res-1"})
+
+    def test_show_accepts_resource_model(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": resource_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+        resource = CkanResourceInfo.from_dict(resource_payload(resource_id="res-2"))
+
+        _ = client.resources.show(resource)
+
+        self.assertEqual(session.calls[0]["json"], {"id": "res-2"})
+
+    def test_patch_adds_resource_id_to_payload(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": resource_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        info = client.resources.patch("res-1", {"description": "Updated"})
+
+        self.assertEqual(info.id, "res-1")
+        self.assertEqual(
+            session.calls[0]["url"],
+            "https://ckan.test/api/3/action/resource_patch",
+        )
+        self.assertEqual(
+            session.calls[0]["json"],
+            {"description": "Updated", "id": "res-1"},
+        )
+
+    def test_patch_uses_resource_model_id(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": resource_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+        resource = CkanResourceInfo.from_dict(resource_payload(resource_id="res-2"))
+
+        _ = client.resources.patch(resource, {"description": "Updated"})
+
+        self.assertEqual(session.calls[0]["json"]["id"], "res-2")
+
+    def test_delete_calls_resource_delete(self):
+        session = FakeSession([FakeResponse(json_value={"success": True, "result": None})])
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        result = client.resources.delete("res-1")
+
+        self.assertIsNone(result)
+        self.assertEqual(
+            session.calls[0]["url"],
+            "https://ckan.test/api/3/action/resource_delete",
+        )
+        self.assertEqual(session.calls[0]["json"], {"id": "res-1"})
+
+    def test_blank_resource_id_is_rejected(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+
+        with self.assertRaisesRegex(ValidationError, "resource id must be non-empty"):
+            client.resources.show(" ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/ckan/test_resources.py
+++ b/tests/unit/services/ckan/test_resources.py
@@ -204,6 +204,13 @@ class TestResourcesResource(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "resource id must be non-empty"):
             client.resources.show(" ")
 
+    def test_blank_resource_model_id_is_rejected(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+        resource = CkanResourceInfo.from_dict(resource_payload(resource_id=" "))
+
+        with self.assertRaisesRegex(ValidationError, "resource id must be non-empty"):
+            client.resources.show(resource)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request implements the focused CKAN package and resource operations required by the Dataportal-facing API. It also adds multipart resource uploads while keeping request construction and response parsing inside the internal CKAN layer.

## Summary

- Added `CkanPackageInfo`, `CkanResourceInfo`, and `CkanPackageSearchResult`, retaining complete raw CKAN payloads.
- Added package create, show, search, patch, and delete operations.
- Added resource create, show, patch, and delete operations.
- Added multipart file upload support to `resource_create`.
- Extended action calls to select JSON or multipart request construction.
- Commits: `881ce90 Add CKAN package operations and models`, `79648c9 Add CKAN resource operations`, `b1b5c6b Add CKAN resource upload support`, and `3dc7216 Format CKAN operation files`.

#### Example

```python
from courier.services.ckan import CkanClient

client = CkanClient("https://ckan.example.org", api_token="secret")
package = client.packages.show("dataset-name")
resource = client.resources.create(
    {"package_id": package.id, "name": "data.csv"},
    upload="data.csv",
)
```

## Unit tests

- Package and resource request payloads.
- Package search parsing and raw-payload preservation.
- Identifier extraction from strings and CKAN models.
- Patch and delete behavior.
- Multipart upload field and file construction.

## Validation

- `black`
- `ruff check`
- `pytest`
- `mypy`