### PR TITLE
Dataportal Client And Metadata Adapter

### DIFF
--- a/courier/services/dataportal/__init__.py
+++ b/courier/services/dataportal/__init__.py
@@ -1,0 +1,5 @@
+"""Material Digital Dataportal client and metadata adapter."""
+
+from courier.services.dataportal.client import DataportalClient
+
+__all__ = ["DataportalClient"]

--- a/courier/services/dataportal/__init__.py
+++ b/courier/services/dataportal/__init__.py
@@ -1,5 +1,6 @@
 """Material Digital Dataportal client and metadata adapter."""
 
 from courier.services.dataportal.client import DataportalClient
+from courier.services.dataportal.metadata import DataportalMetadata
 
-__all__ = ["DataportalClient"]
+__all__ = ["DataportalClient", "DataportalMetadata"]

--- a/courier/services/dataportal/client.py
+++ b/courier/services/dataportal/client.py
@@ -1,0 +1,32 @@
+"""Material Digital Dataportal client."""
+
+from __future__ import annotations
+
+import requests
+
+from courier.services.ckan.client import CkanClient
+
+DEFAULT_DATAPORTAL_ADDRESS = "dataportal.material-digital.de"
+
+
+class DataportalClient(CkanClient):
+    """Client for the CKAN-backed Material Digital Dataportal."""
+
+    def __init__(
+        self,
+        address: str | None = None,
+        *,
+        api_token: str | None = None,
+        default_scheme: str = "https",
+        verify: bool | str = True,
+        timeout: float | tuple[float, float] = 30.0,
+        session: requests.Session | None = None,
+    ) -> None:
+        super().__init__(
+            address or DEFAULT_DATAPORTAL_ADDRESS,
+            api_token=api_token,
+            default_scheme=default_scheme,
+            verify=verify,
+            timeout=timeout,
+            session=session,
+        )

--- a/courier/services/dataportal/metadata.py
+++ b/courier/services/dataportal/metadata.py
@@ -1,0 +1,206 @@
+"""Dataportal-specific adaptation of publication metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from typing import Any
+
+from courier.exceptions import ValidationError
+from courier.metadata import Contributor, Person, PublicationMetadata, RelatedIdentifier
+
+
+@dataclass
+class DataportalMetadata:
+    """Adapt service-neutral publication metadata to a CKAN package payload."""
+
+    metadata: PublicationMetadata
+    name: str | None = None
+    owner_org: str | None = None
+    private: bool | None = None
+    groups: list[str] = field(default_factory=list)
+    extras: dict[str, str] = field(default_factory=dict)
+    dataset_type: str | None = None
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """Validate Dataportal-specific fields and adapter boundaries."""
+        if not isinstance(self.metadata, PublicationMetadata):
+            raise ValidationError("metadata must be a PublicationMetadata instance")
+
+        if self.name is not None:
+            _ = _required_string(self.name, "name")
+        if self.owner_org is not None:
+            _ = _required_string(self.owner_org, "owner_org")
+        if self.dataset_type is not None:
+            _ = _required_string(self.dataset_type, "dataset_type")
+        if self.private is not None and not isinstance(self.private, bool):
+            raise ValidationError("private must be a boolean when provided")
+
+        for group in self.groups:
+            _ = _required_string(group, "group")
+
+        normalized_extra_keys: set[str] = set()
+        for key, value in self.extras.items():
+            normalized_key = _required_string(key, "extra key")
+            if normalized_key in normalized_extra_keys:
+                raise ValidationError(
+                    f"duplicate extra key after normalization: {normalized_key!r}"
+                )
+            normalized_extra_keys.add(normalized_key)
+            if not isinstance(value, str):
+                raise ValidationError("extra values must be strings")
+
+        conflicts = sorted(normalized_extra_keys & _generated_extra_keys(self.metadata))
+        if conflicts:
+            raise ValidationError(
+                "extras conflict with PublicationMetadata fields: "
+                + ", ".join(conflicts)
+            )
+
+        _ = self._package_name()
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize metadata to a CKAN package action payload."""
+        self.validate()
+
+        payload: dict[str, Any] = {
+            "name": self._package_name(),
+            "title": self.metadata.title,
+            "notes": self.metadata.description,
+            "tags": [{"name": keyword} for keyword in self.metadata.keywords],
+        }
+
+        _add_if_present(payload, "owner_org", self.owner_org)
+        if self.private is not None:
+            payload["private"] = self.private
+        _add_if_present(payload, "license_id", self.metadata.license)
+        _add_if_present(payload, "version", self.metadata.version)
+        _add_if_present(payload, "type", self.dataset_type)
+
+        if self.groups:
+            payload["groups"] = [
+                {"name": _required_string(group, "group")} for group in self.groups
+            ]
+
+        extras = self._serialized_extras()
+        if extras:
+            payload["extras"] = [
+                {"key": key, "value": value} for key, value in extras.items()
+            ]
+
+        return payload
+
+    def _package_name(self) -> str:
+        if self.name is not None:
+            return _required_string(self.name, "name")
+
+        name = _slugify(self.metadata.title)
+        if not name:
+            raise ValidationError(
+                "name must be provided when title cannot produce a CKAN package name"
+            )
+        return name
+
+    def _serialized_extras(self) -> dict[str, str]:
+        extras = {
+            _required_string(key, "extra key"): value
+            for key, value in self.extras.items()
+        }
+
+        if self.metadata.publication_date is not None:
+            extras["publication_date"] = self.metadata.publication_date.isoformat()
+        if self.metadata.doi is not None:
+            extras["doi"] = self.metadata.doi
+        if self.metadata.language is not None:
+            extras["language"] = self.metadata.language
+
+        extras["creators"] = _json_value(
+            [_person_dict(person) for person in self.metadata.creators]
+        )
+        if self.metadata.contributors:
+            extras["contributors"] = _json_value(
+                [_contributor_dict(item) for item in self.metadata.contributors]
+            )
+        if self.metadata.related_identifiers:
+            extras["related_identifiers"] = _json_value(
+                [
+                    _related_identifier_dict(item)
+                    for item in self.metadata.related_identifiers
+                ]
+            )
+
+        return extras
+
+
+def _generated_extra_keys(metadata: PublicationMetadata) -> set[str]:
+    keys = {"creators"}
+    if metadata.publication_date is not None:
+        keys.add("publication_date")
+    if metadata.doi is not None:
+        keys.add("doi")
+    if metadata.language is not None:
+        keys.add("language")
+    if metadata.contributors:
+        keys.add("contributors")
+    if metadata.related_identifiers:
+        keys.add("related_identifiers")
+    return keys
+
+
+def _person_dict(person: Person) -> dict[str, str]:
+    data: dict[str, str] = {}
+    _add_if_present(data, "family_name", person.family_name)
+    _add_if_present(data, "given_names", person.given_names)
+    _add_if_present(data, "name", person.name)
+    _add_if_present(data, "affiliation", person.affiliation)
+    _add_if_present(data, "orcid", person.orcid)
+    _add_if_present(data, "gnd", person.gnd)
+    return data
+
+
+def _contributor_dict(contributor: Contributor) -> dict[str, Any]:
+    data: dict[str, Any] = {"person": _person_dict(contributor.person)}
+    _add_if_present(data, "role", contributor.role)
+    return data
+
+
+def _related_identifier_dict(
+    related_identifier: RelatedIdentifier,
+) -> dict[str, str]:
+    data = {
+        "identifier": related_identifier.identifier,
+        "relation": related_identifier.relation,
+    }
+    _add_if_present(data, "resource_type", related_identifier.resource_type)
+    return data
+
+
+def _json_value(value: object) -> str:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+
+
+def _slugify(value: str) -> str:
+    ascii_value = (
+        unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    )
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_value.lower())
+    return slug.strip("-")
+
+
+def _required_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+def _add_if_present(data: dict[str, Any], key: str, value: object) -> None:
+    if isinstance(value, str):
+        if value.strip():
+            data[key] = value.strip()
+    elif value is not None:
+        data[key] = value

--- a/courier/services/dataportal/metadata.py
+++ b/courier/services/dataportal/metadata.py
@@ -198,9 +198,6 @@ def _required_string(value: object, field_name: str) -> str:
     return value.strip()
 
 
-def _add_if_present(data: dict[str, Any], key: str, value: object) -> None:
-    if isinstance(value, str):
-        if value.strip():
-            data[key] = value.strip()
-    elif value is not None:
-        data[key] = value
+def _add_if_present(data: dict[str, Any], key: str, value: str | None) -> None:
+    if value is not None and value.strip():
+        data[key] = value.strip()

--- a/courier/services/dataportal/metadata.py
+++ b/courier/services/dataportal/metadata.py
@@ -41,9 +41,13 @@ class DataportalMetadata:
         if self.private is not None and not isinstance(self.private, bool):
             raise ValidationError("private must be a boolean when provided")
 
+        if not isinstance(self.groups, list):
+            raise ValidationError("groups must be a list")
         for group in self.groups:
             _ = _required_string(group, "group")
 
+        if not isinstance(self.extras, dict):
+            raise ValidationError("extras must be a dict")
         normalized_extra_keys: set[str] = set()
         for key, value in self.extras.items():
             normalized_key = _required_string(key, "extra key")

--- a/tests/unit/services/dataportal/__init__.py
+++ b/tests/unit/services/dataportal/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Dataportal service client."""

--- a/tests/unit/services/dataportal/_helpers.py
+++ b/tests/unit/services/dataportal/_helpers.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+
+class FakeResponse:
+    def __init__(self, *, json_value: Any = None):
+        self.url = "https://dataportal.material-digital.de"
+        self.status_code = 200
+        self.text = ""
+        self.request = None
+        self._json_value = json_value
+
+    def json(self) -> Any:
+        return self._json_value
+
+
+class FakeSession:
+    def __init__(self):
+        self.headers: dict[str, str] = {}
+        self.calls: list[dict[str, Any]] = []
+
+    def request(self, method: str, url: str, **kwargs: Any) -> FakeResponse:
+        self.calls.append({"method": method, "url": url, **kwargs})
+        return FakeResponse()

--- a/tests/unit/services/dataportal/test_client.py
+++ b/tests/unit/services/dataportal/test_client.py
@@ -1,0 +1,47 @@
+import unittest
+from typing import Any, cast
+
+import courier
+from courier.services.dataportal import DataportalClient
+
+from ._helpers import FakeSession
+
+
+class TestDataportalClient(unittest.TestCase):
+    def test_default_address_is_material_digital_dataportal(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        self.assertEqual(
+            client.base_url,
+            "https://dataportal.material-digital.de",
+        )
+        self.assertIs(client.action.client, client)
+        self.assertIs(client.packages.client, client)
+        self.assertIs(client.resources.client, client)
+
+    def test_custom_address_and_default_scheme_are_supported(self):
+        client = DataportalClient(
+            "localhost:5000",
+            default_scheme="http",
+            session=cast(Any, FakeSession()),
+        )
+
+        self.assertEqual(client.base_url, "http://localhost:5000")
+
+    def test_api_token_uses_ckan_raw_authorization_header(self):
+        session = FakeSession()
+
+        client = DataportalClient(
+            api_token="  token  ",
+            session=cast(Any, session),
+        )
+
+        self.assertEqual(client.api_token, "token")
+        self.assertEqual(session.headers["Authorization"], "token")
+
+    def test_client_is_not_exported_from_top_level_package(self):
+        self.assertFalse(hasattr(courier, "DataportalClient"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/dataportal/test_metadata.py
+++ b/tests/unit/services/dataportal/test_metadata.py
@@ -186,6 +186,24 @@ class TestDataportalMetadata(unittest.TestCase):
                 private=cast(Any, "false"),
             )
 
+    def test_groups_and_extras_require_expected_container_types(self):
+        cases = [
+            ({"groups": None}, "groups must be a list"),
+            ({"groups": "foo"}, "groups must be a list"),
+            ({"extras": None}, "extras must be a dict"),
+            ({"extras": []}, "extras must be a dict"),
+        ]
+
+        for kwargs, message in cases:
+            with (
+                self.subTest(kwargs=kwargs),
+                self.assertRaisesRegex(ValidationError, message),
+            ):
+                DataportalMetadata(
+                    metadata=publication_metadata(),
+                    **cast(Any, kwargs),
+                )
+
     def test_extra_values_must_be_strings(self):
         with self.assertRaisesRegex(ValidationError, "extra values must be strings"):
             DataportalMetadata(

--- a/tests/unit/services/dataportal/test_metadata.py
+++ b/tests/unit/services/dataportal/test_metadata.py
@@ -1,0 +1,205 @@
+import json
+import unittest
+from typing import Any, cast
+
+from courier.exceptions import ValidationError
+from courier.metadata import (
+    Contributor,
+    Person,
+    PublicationMetadata,
+    RelatedIdentifier,
+)
+from courier.services.dataportal import DataportalMetadata
+
+
+def publication_metadata(**overrides: Any) -> PublicationMetadata:
+    values: dict[str, Any] = {
+        "title": "Steel Heat Treatment Data",
+        "description": "Measurements from a heat treatment experiment.",
+        "publication_date": "2026-06-08",
+        "creators": [
+            Person(
+                family_name="Doe",
+                given_names="Jane",
+                affiliation="MPI-SusMat",
+                orcid="0000-0000-0000-0000",
+            )
+        ],
+        "contributors": [
+            Contributor(
+                person=Person(name="Curator, Chris"),
+                role="DataCurator",
+            )
+        ],
+        "keywords": ["steel", "heat treatment"],
+        "license": "CC-BY-4.0",
+        "doi": "10.1234/example",
+        "version": "1.0.0",
+        "language": "eng",
+        "related_identifiers": [
+            RelatedIdentifier(
+                identifier="10.1234/source",
+                relation="isDerivedFrom",
+                resource_type="dataset",
+            )
+        ],
+    }
+    values.update(overrides)
+    return PublicationMetadata(**values)
+
+
+def extras_by_key(payload: dict[str, Any]) -> dict[str, str]:
+    return {item["key"]: item["value"] for item in payload.get("extras", [])}
+
+
+class TestDataportalMetadata(unittest.TestCase):
+    def test_serializes_publication_and_dataportal_fields(self):
+        metadata = DataportalMetadata(
+            metadata=publication_metadata(),
+            owner_org="materials-org",
+            private=False,
+            groups=["heat-treatment"],
+            extras={"pmd_profile": "dataset-v1"},
+            dataset_type="dataset",
+        )
+
+        payload = metadata.to_payload()
+
+        self.assertEqual(payload["name"], "steel-heat-treatment-data")
+        self.assertEqual(payload["title"], "Steel Heat Treatment Data")
+        self.assertEqual(
+            payload["notes"],
+            "Measurements from a heat treatment experiment.",
+        )
+        self.assertEqual(
+            payload["tags"],
+            [{"name": "steel"}, {"name": "heat treatment"}],
+        )
+        self.assertEqual(payload["license_id"], "CC-BY-4.0")
+        self.assertEqual(payload["version"], "1.0.0")
+        self.assertEqual(payload["owner_org"], "materials-org")
+        self.assertFalse(payload["private"])
+        self.assertEqual(payload["groups"], [{"name": "heat-treatment"}])
+        self.assertEqual(payload["type"], "dataset")
+
+        extras = extras_by_key(payload)
+        self.assertEqual(extras["pmd_profile"], "dataset-v1")
+        self.assertEqual(extras["publication_date"], "2026-06-08")
+        self.assertEqual(extras["doi"], "10.1234/example")
+        self.assertEqual(extras["language"], "eng")
+        self.assertEqual(
+            json.loads(extras["creators"]),
+            [
+                {
+                    "affiliation": "MPI-SusMat",
+                    "family_name": "Doe",
+                    "given_names": "Jane",
+                    "orcid": "0000-0000-0000-0000",
+                }
+            ],
+        )
+        self.assertEqual(
+            json.loads(extras["contributors"]),
+            [
+                {
+                    "person": {"name": "Curator, Chris"},
+                    "role": "DataCurator",
+                }
+            ],
+        )
+        self.assertEqual(
+            json.loads(extras["related_identifiers"]),
+            [
+                {
+                    "identifier": "10.1234/source",
+                    "relation": "isDerivedFrom",
+                    "resource_type": "dataset",
+                }
+            ],
+        )
+
+    def test_explicit_name_is_trimmed(self):
+        metadata = DataportalMetadata(
+            metadata=publication_metadata(),
+            name="  explicit-dataset-name  ",
+        )
+
+        self.assertEqual(metadata.to_payload()["name"], "explicit-dataset-name")
+
+    def test_optional_publication_values_are_omitted(self):
+        publication = publication_metadata(
+            publication_date=None,
+            contributors=[],
+            keywords=[],
+            license=None,
+            doi=None,
+            version=None,
+            language=None,
+            related_identifiers=[],
+        )
+
+        payload = DataportalMetadata(metadata=publication).to_payload()
+        extras = extras_by_key(payload)
+
+        self.assertEqual(payload["tags"], [])
+        self.assertNotIn("license_id", payload)
+        self.assertNotIn("version", payload)
+        self.assertEqual(set(extras), {"creators"})
+
+    def test_generated_extra_collision_is_rejected(self):
+        with self.assertRaisesRegex(ValidationError, "publication_date"):
+            DataportalMetadata(
+                metadata=publication_metadata(),
+                extras={"publication_date": "override"},
+            )
+
+    def test_blank_dataportal_fields_are_rejected(self):
+        cases = [
+            ({"name": " "}, "name"),
+            ({"owner_org": " "}, "owner_org"),
+            ({"dataset_type": " "}, "dataset_type"),
+            ({"groups": [" "]}, "group"),
+            ({"extras": {" ": "value"}}, "extra key"),
+        ]
+
+        for kwargs, message in cases:
+            with (
+                self.subTest(kwargs=kwargs),
+                self.assertRaisesRegex(ValidationError, message),
+            ):
+                DataportalMetadata(metadata=publication_metadata(), **kwargs)
+
+    def test_private_must_be_boolean(self):
+        with self.assertRaisesRegex(ValidationError, "private must be a boolean"):
+            DataportalMetadata(
+                metadata=publication_metadata(),
+                private=cast(Any, "false"),
+            )
+
+    def test_extra_values_must_be_strings(self):
+        with self.assertRaisesRegex(ValidationError, "extra values must be strings"):
+            DataportalMetadata(
+                metadata=publication_metadata(),
+                extras=cast(Any, {"priority": 1}),
+            )
+
+    def test_metadata_must_be_publication_metadata(self):
+        with self.assertRaisesRegex(ValidationError, "PublicationMetadata"):
+            DataportalMetadata(metadata=cast(Any, {"title": "raw"}))
+
+    def test_name_is_required_when_title_cannot_form_ascii_slug(self):
+        with self.assertRaisesRegex(ValidationError, "name must be provided"):
+            DataportalMetadata(
+                metadata=publication_metadata(title="材料"),
+            )
+
+    def test_serialization_revalidates_mutable_specific_fields(self):
+        metadata = DataportalMetadata(metadata=publication_metadata())
+        metadata.groups.append(" ")
+
+        with self.assertRaisesRegex(ValidationError, "group"):
+            metadata.to_payload()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/dataportal/test_metadata.py
+++ b/tests/unit/services/dataportal/test_metadata.py
@@ -153,6 +153,16 @@ class TestDataportalMetadata(unittest.TestCase):
                 extras={"publication_date": "override"},
             )
 
+    def test_duplicate_normalized_extra_keys_are_rejected(self):
+        with self.assertRaisesRegex(
+            ValidationError,
+            "duplicate extra key after normalization: 'profile'",
+        ):
+            DataportalMetadata(
+                metadata=publication_metadata(),
+                extras={"profile": "first", " profile ": "second"},
+            )
+
     def test_blank_dataportal_fields_are_rejected(self):
         cases = [
             ({"name": " "}, "name"),

--- a/tests/unit/services/dataportal/test_metadata_boundary.py
+++ b/tests/unit/services/dataportal/test_metadata_boundary.py
@@ -1,0 +1,75 @@
+import unittest
+from dataclasses import fields
+from typing import Any, cast
+
+import courier
+from courier.metadata import Person, PublicationMetadata
+from courier.services.dataportal import DataportalMetadata
+
+
+def publication_metadata() -> PublicationMetadata:
+    return PublicationMetadata(
+        title="Reusable dataset",
+        description="Service-neutral publication metadata.",
+        creators=[Person(name="Doe, Jane")],
+        keywords=["materials"],
+        license="CC-BY-4.0",
+    )
+
+
+class TestDataportalMetadataBoundary(unittest.TestCase):
+    def test_adapter_contains_only_publication_reference_and_ckan_fields(self):
+        self.assertEqual(
+            {item.name for item in fields(DataportalMetadata)},
+            {
+                "metadata",
+                "name",
+                "owner_org",
+                "private",
+                "groups",
+                "extras",
+                "dataset_type",
+            },
+        )
+
+    def test_generic_fields_cannot_be_passed_to_adapter_constructor(self):
+        generic_fields = {
+            "title": "Duplicate title",
+            "notes": "Duplicate description",
+            "tags": ["duplicate"],
+            "license_id": "MIT",
+            "version": "2.0",
+        }
+
+        for field_name, value in generic_fields.items():
+            with (
+                self.subTest(field_name=field_name),
+                self.assertRaises(TypeError),
+            ):
+                DataportalMetadata(
+                    metadata=publication_metadata(),
+                    **cast(Any, {field_name: value}),
+                )
+
+    def test_generic_payload_fields_are_sourced_from_publication_metadata(self):
+        publication = publication_metadata()
+
+        payload = DataportalMetadata(
+            metadata=publication,
+            name="explicit-name",
+        ).to_payload()
+
+        self.assertEqual(payload["title"], publication.title)
+        self.assertEqual(payload["notes"], publication.description)
+        self.assertEqual(
+            payload["tags"],
+            [{"name": keyword} for keyword in publication.keywords],
+        )
+        self.assertEqual(payload["license_id"], publication.license)
+
+    def test_adapter_is_not_exported_from_top_level_package(self):
+        self.assertFalse(hasattr(courier, "DataportalMetadata"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request adds the public Dataportal client and its service-specific metadata adapter. Generic publication information remains owned by `PublicationMetadata`, while `DataportalMetadata` contains only Dataportal and CKAN concerns and converts both layers into a CKAN package payload.

## Summary

- Added `DataportalClient` with the default `dataportal.material-digital.de` address and support for custom deployments.
- Exported `DataportalClient` and `DataportalMetadata` from `courier.services.dataportal`, but not from the top-level package.
- Required generic fields to enter through `PublicationMetadata`.
- Restricted `DataportalMetadata` to Dataportal/CKAN fields such as `name`, `owner_org`, `private`, `groups`, `extras`, and `dataset_type`.
- Mapped publication fields into CKAN fields and deterministic structured extras.
- Added package-name derivation and metadata collision validation.
- Commits: `64b5618 Add Dataportal client skeleton`, `82b6062 Add Dataportal metadata adapter`, and `1d7a0ab Test Dataportal metadata boundary`.

## Example

```python
from courier.metadata import Person, PublicationMetadata
from courier.services.dataportal import DataportalClient, DataportalMetadata

client = DataportalClient(api_token="secret")
publication = PublicationMetadata(
    title="Example dataset",
    description="Example description",
    creators=(Person(name="Example Author"),),
)
metadata = DataportalMetadata(
    metadata=publication,
    owner_org="example-organization",
)
dataset = client.packages.create(metadata.to_payload())
```

## Unit tests

- Default and custom Dataportal addresses.
- Public export boundaries.
- Publication-to-CKAN field conversion.
- Deterministic structured-extra serialization.
- Name derivation and blank-field validation.
- Rejection of generic publication fields passed directly to `DataportalMetadata`.

## Validation

- `black`
- `ruff check`
- `pytest`
- `mypy