### PR TITLE
Dataportal Dataset Resource

### DIFF
--- a/courier/services/dataportal/__init__.py
+++ b/courier/services/dataportal/__init__.py
@@ -2,5 +2,14 @@
 
 from courier.services.dataportal.client import DataportalClient
 from courier.services.dataportal.metadata import DataportalMetadata
+from courier.services.dataportal.models import (
+    DataportalDatasetInfo,
+    DataportalDatasetSearchResult,
+)
 
-__all__ = ["DataportalClient", "DataportalMetadata"]
+__all__ = [
+    "DataportalClient",
+    "DataportalDatasetInfo",
+    "DataportalDatasetSearchResult",
+    "DataportalMetadata",
+]

--- a/courier/services/dataportal/client.py
+++ b/courier/services/dataportal/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import requests
 
 from courier.services.ckan.client import CkanClient
+from courier.services.dataportal.datasets import DatasetsResource
 
 DEFAULT_DATAPORTAL_ADDRESS = "dataportal.material-digital.de"
 
@@ -30,3 +31,4 @@ class DataportalClient(CkanClient):
             timeout=timeout,
             session=session,
         )
+        self.datasets = DatasetsResource(self)

--- a/courier/services/dataportal/datasets.py
+++ b/courier/services/dataportal/datasets.py
@@ -81,6 +81,4 @@ def _metadata_payload(metadata: DatasetMetadata) -> dict[str, Any]:
         )
     if isinstance(metadata, Mapping):
         return dict(metadata)
-    raise ValidationError(
-        "dataset metadata must be DataportalMetadata or a mapping"
-    )
+    raise ValidationError("dataset metadata must be DataportalMetadata or a mapping")

--- a/courier/services/dataportal/datasets.py
+++ b/courier/services/dataportal/datasets.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from courier.exceptions import ValidationError
+from courier.metadata import PublicationMetadata
+from courier.services.dataportal.metadata import DataportalMetadata
 from courier.services.dataportal.models import (
     DataportalDatasetInfo,
     DataportalDatasetSearchResult,
@@ -14,12 +17,19 @@ from courier.services.dataportal.models import (
 if TYPE_CHECKING:
     from courier.services.dataportal.client import DataportalClient
 
+DatasetMetadata: TypeAlias = DataportalMetadata | Mapping[str, Any]
+
 
 @dataclass
 class DatasetsResource:
     """Dataportal-facing dataset operations."""
 
     client: DataportalClient
+
+    def create(self, metadata: DatasetMetadata) -> DataportalDatasetInfo:
+        """Create a Dataportal dataset."""
+        package = self.client.packages.create(_metadata_payload(metadata))
+        return DataportalDatasetInfo.from_ckan(package)
 
     def show(self, dataset: str | DataportalDatasetInfo) -> DataportalDatasetInfo:
         """Retrieve a Dataportal dataset by id, name, or dataset model."""
@@ -35,6 +45,18 @@ class DatasetsResource:
         result = self.client.packages.search(query, **filters)
         return DataportalDatasetSearchResult.from_ckan(result)
 
+    def patch(
+        self,
+        dataset: str | DataportalDatasetInfo,
+        metadata: DatasetMetadata,
+    ) -> DataportalDatasetInfo:
+        """Partially update a Dataportal dataset."""
+        package = self.client.packages.patch(
+            _dataset_id(dataset),
+            _metadata_payload(metadata),
+        )
+        return DataportalDatasetInfo.from_ckan(package)
+
     def delete(self, dataset: str | DataportalDatasetInfo) -> None:
         """Delete a Dataportal dataset."""
         self.client.packages.delete(_dataset_id(dataset))
@@ -47,3 +69,18 @@ def _dataset_id(dataset: str | DataportalDatasetInfo) -> str:
     if not text:
         raise ValidationError("dataset id must be non-empty")
     return text
+
+
+def _metadata_payload(metadata: DatasetMetadata) -> dict[str, Any]:
+    if isinstance(metadata, DataportalMetadata):
+        return metadata.to_payload()
+    if isinstance(metadata, PublicationMetadata):
+        raise ValidationError(
+            "dataset metadata must be wrapped in DataportalMetadata; "
+            "plain PublicationMetadata is not accepted"
+        )
+    if isinstance(metadata, Mapping):
+        return dict(metadata)
+    raise ValidationError(
+        "dataset metadata must be DataportalMetadata or a mapping"
+    )

--- a/courier/services/dataportal/datasets.py
+++ b/courier/services/dataportal/datasets.py
@@ -1,0 +1,49 @@
+"""Dataportal dataset operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from courier.exceptions import ValidationError
+from courier.services.dataportal.models import (
+    DataportalDatasetInfo,
+    DataportalDatasetSearchResult,
+)
+
+if TYPE_CHECKING:
+    from courier.services.dataportal.client import DataportalClient
+
+
+@dataclass
+class DatasetsResource:
+    """Dataportal-facing dataset operations."""
+
+    client: DataportalClient
+
+    def show(self, dataset: str | DataportalDatasetInfo) -> DataportalDatasetInfo:
+        """Retrieve a Dataportal dataset by id, name, or dataset model."""
+        package = self.client.packages.show(_dataset_id(dataset))
+        return DataportalDatasetInfo.from_ckan(package)
+
+    def search(
+        self,
+        query: str | None = None,
+        **filters: Any,
+    ) -> DataportalDatasetSearchResult:
+        """Search Dataportal datasets."""
+        result = self.client.packages.search(query, **filters)
+        return DataportalDatasetSearchResult.from_ckan(result)
+
+    def delete(self, dataset: str | DataportalDatasetInfo) -> None:
+        """Delete a Dataportal dataset."""
+        self.client.packages.delete(_dataset_id(dataset))
+
+
+def _dataset_id(dataset: str | DataportalDatasetInfo) -> str:
+    if isinstance(dataset, DataportalDatasetInfo):
+        return dataset.id
+    text = str(dataset).strip()
+    if not text:
+        raise ValidationError("dataset id must be non-empty")
+    return text

--- a/courier/services/dataportal/models.py
+++ b/courier/services/dataportal/models.py
@@ -1,0 +1,84 @@
+"""Dataportal-facing dataset models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from courier.exceptions import ValidationError
+from courier.services.ckan.models import CkanPackageInfo, CkanPackageSearchResult
+
+
+@dataclass(frozen=True)
+class DataportalDatasetInfo:
+    """Important fields returned for a Dataportal dataset."""
+
+    id: str
+    name: str
+    title: str | None
+    notes: str | None
+    owner_org: str | None
+    private: bool | None
+    dataset_type: str | None
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_ckan(cls, package: CkanPackageInfo) -> DataportalDatasetInfo:
+        """Build a Dataportal dataset model from an internal CKAN model."""
+        return cls(
+            id=package.id,
+            name=package.name,
+            title=package.title,
+            notes=_optional_string(package.raw.get("notes")),
+            owner_org=_optional_string(package.raw.get("owner_org")),
+            private=_optional_bool(package.raw.get("private")),
+            dataset_type=_optional_string(package.raw.get("type")),
+            raw=dict(package.raw),
+        )
+
+
+@dataclass(frozen=True)
+class DataportalDatasetSearchResult:
+    """Dataportal dataset search result."""
+
+    count: int
+    results: list[DataportalDatasetInfo]
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_ckan(
+        cls,
+        result: CkanPackageSearchResult,
+    ) -> DataportalDatasetSearchResult:
+        """Build a Dataportal search model from an internal CKAN result."""
+        return cls(
+            count=result.count,
+            results=[
+                DataportalDatasetInfo.from_ckan(package)
+                for package in result.results
+            ],
+            raw=dict(result.raw),
+        )
+
+
+def _optional_string(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_bool(value: object) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise ValidationError("private must be a boolean value")

--- a/courier/services/dataportal/models.py
+++ b/courier/services/dataportal/models.py
@@ -72,7 +72,7 @@ def _optional_bool(value: object) -> bool | None:
         return None
     if isinstance(value, bool):
         return value
-    if value in (0, 1):
+    if type(value) is int and value in (0, 1):
         return bool(value)
     if isinstance(value, str):
         normalized = value.strip().lower()

--- a/courier/services/dataportal/models.py
+++ b/courier/services/dataportal/models.py
@@ -54,8 +54,7 @@ class DataportalDatasetSearchResult:
         return cls(
             count=result.count,
             results=[
-                DataportalDatasetInfo.from_ckan(package)
-                for package in result.results
+                DataportalDatasetInfo.from_ckan(package) for package in result.results
             ],
             raw=dict(result.raw),
         )

--- a/tests/unit/services/dataportal/test_client.py
+++ b/tests/unit/services/dataportal/test_client.py
@@ -18,6 +18,7 @@ class TestDataportalClient(unittest.TestCase):
         self.assertIs(client.action.client, client)
         self.assertIs(client.packages.client, client)
         self.assertIs(client.resources.client, client)
+        self.assertIs(client.datasets.client, client)
 
     def test_custom_address_and_default_scheme_are_supported(self):
         client = DataportalClient(

--- a/tests/unit/services/dataportal/test_client.py
+++ b/tests/unit/services/dataportal/test_client.py
@@ -2,6 +2,7 @@ import unittest
 from typing import Any, cast
 
 import courier
+from courier.metadata import Person, PublicationMetadata
 from courier.services.dataportal import DataportalClient
 
 from ._helpers import FakeSession
@@ -42,6 +43,19 @@ class TestDataportalClient(unittest.TestCase):
 
     def test_client_is_not_exported_from_top_level_package(self):
         self.assertFalse(hasattr(courier, "DataportalClient"))
+
+    def test_client_construction_does_not_accept_publication_metadata(self):
+        metadata = PublicationMetadata(
+            title="Dataset",
+            description="Data.",
+            creators=[Person(name="Doe, Jane")],
+        )
+
+        with self.assertRaises(TypeError):
+            cast(Any, DataportalClient)(
+                metadata=metadata,
+                session=cast(Any, FakeSession()),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit/services/dataportal/test_datasets.py
+++ b/tests/unit/services/dataportal/test_datasets.py
@@ -42,7 +42,9 @@ class StubPackagesResource:
         self.calls.append(("create", payload))
         return CkanPackageInfo.from_dict(package_payload())
 
-    def search(self, query: str | None = None, **filters: Any) -> CkanPackageSearchResult:
+    def search(
+        self, query: str | None = None, **filters: Any
+    ) -> CkanPackageSearchResult:
         self.calls.append(("search", query, filters))
         return CkanPackageSearchResult.from_dict(
             {"count": 1, "results": [package_payload()]}

--- a/tests/unit/services/dataportal/test_datasets.py
+++ b/tests/unit/services/dataportal/test_datasets.py
@@ -2,10 +2,12 @@ import unittest
 from typing import Any, cast
 
 from courier.exceptions import ValidationError
+from courier.metadata import Person, PublicationMetadata
 from courier.services.ckan.models import CkanPackageInfo, CkanPackageSearchResult
 from courier.services.dataportal import (
     DataportalClient,
     DataportalDatasetInfo,
+    DataportalMetadata,
 )
 
 from ._helpers import FakeSession
@@ -36,11 +38,19 @@ class StubPackagesResource:
         self.calls.append(("show", package))
         return CkanPackageInfo.from_dict(package_payload())
 
+    def create(self, payload: dict[str, Any]) -> CkanPackageInfo:
+        self.calls.append(("create", payload))
+        return CkanPackageInfo.from_dict(package_payload())
+
     def search(self, query: str | None = None, **filters: Any) -> CkanPackageSearchResult:
         self.calls.append(("search", query, filters))
         return CkanPackageSearchResult.from_dict(
             {"count": 1, "results": [package_payload()]}
         )
+
+    def patch(self, package: str, payload: dict[str, Any]) -> CkanPackageInfo:
+        self.calls.append(("patch", package, payload))
+        return CkanPackageInfo.from_dict(package_payload())
 
     def delete(self, package: str) -> None:
         self.calls.append(("delete", package))
@@ -53,7 +63,61 @@ def client_with_stub() -> tuple[DataportalClient, StubPackagesResource]:
     return client, packages
 
 
+def publication_metadata() -> PublicationMetadata:
+    return PublicationMetadata(
+        title="Steel data",
+        description="Heat treatment measurements.",
+        creators=[Person(name="Doe, Jane")],
+        keywords=["steel"],
+        license="CC-BY-4.0",
+    )
+
+
 class TestDatasetsResource(unittest.TestCase):
+    def test_create_serializes_dataportal_metadata_before_delegation(self):
+        client, packages = client_with_stub()
+        metadata = DataportalMetadata(
+            metadata=publication_metadata(),
+            owner_org="materials-org",
+            private=False,
+        )
+
+        dataset = client.datasets.create(metadata)
+
+        self.assertEqual(dataset.id, "pkg-1")
+        self.assertEqual(
+            packages.calls,
+            [
+                (
+                    "create",
+                    {
+                        "name": "steel-data",
+                        "title": "Steel data",
+                        "notes": "Heat treatment measurements.",
+                        "tags": [{"name": "steel"}],
+                        "owner_org": "materials-org",
+                        "private": False,
+                        "license_id": "CC-BY-4.0",
+                        "extras": [
+                            {
+                                "key": "creators",
+                                "value": '[{"name":"Doe, Jane"}]',
+                            }
+                        ],
+                    },
+                )
+            ],
+        )
+
+    def test_create_preserves_raw_mapping_escape_hatch(self):
+        client, packages = client_with_stub()
+        payload = {"name": "raw-dataset", "title": "Raw dataset"}
+
+        dataset = client.datasets.create(payload)
+
+        self.assertEqual(dataset.name, "steel-data")
+        self.assertEqual(packages.calls, [("create", payload)])
+
     def test_show_delegates_to_packages_and_converts_result(self):
         client, packages = client_with_stub()
 
@@ -84,6 +148,63 @@ class TestDatasetsResource(unittest.TestCase):
             packages.calls,
             [("search", "steel", {"rows": 5, "fq": "private:false"})],
         )
+
+    def test_patch_serializes_dataportal_metadata_and_uses_dataset_id(self):
+        client, packages = client_with_stub()
+        dataset = DataportalDatasetInfo.from_ckan(
+            CkanPackageInfo.from_dict(package_payload(package_id="pkg-2"))
+        )
+        metadata = DataportalMetadata(
+            metadata=publication_metadata(),
+            name="steel-data",
+        )
+
+        updated = client.datasets.patch(dataset, metadata)
+
+        self.assertEqual(updated.id, "pkg-1")
+        self.assertEqual(packages.calls[0][0:2], ("patch", "pkg-2"))
+        self.assertEqual(packages.calls[0][2]["title"], "Steel data")
+
+    def test_patch_preserves_raw_mapping_escape_hatch(self):
+        client, packages = client_with_stub()
+        payload = {"private": True}
+
+        _ = client.datasets.patch("steel-data", payload)
+
+        self.assertEqual(packages.calls, [("patch", "steel-data", payload)])
+
+    def test_plain_publication_metadata_is_rejected_for_create_and_patch(self):
+        client, packages = client_with_stub()
+        publication = publication_metadata()
+
+        for operation in (
+            lambda: client.datasets.create(cast(Any, publication)),
+            lambda: client.datasets.patch(
+                "steel-data",
+                cast(Any, publication),
+            ),
+        ):
+            with (
+                self.subTest(operation=operation),
+                self.assertRaisesRegex(
+                    ValidationError,
+                    "wrapped in DataportalMetadata",
+                ),
+            ):
+                operation()
+
+        self.assertEqual(packages.calls, [])
+
+    def test_invalid_metadata_type_is_rejected(self):
+        client, packages = client_with_stub()
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "DataportalMetadata or a mapping",
+        ):
+            client.datasets.create(cast(Any, object()))
+
+        self.assertEqual(packages.calls, [])
 
     def test_delete_delegates_dataset_id(self):
         client, packages = client_with_stub()

--- a/tests/unit/services/dataportal/test_datasets.py
+++ b/tests/unit/services/dataportal/test_datasets.py
@@ -1,0 +1,106 @@
+import unittest
+from typing import Any, cast
+
+from courier.exceptions import ValidationError
+from courier.services.ckan.models import CkanPackageInfo, CkanPackageSearchResult
+from courier.services.dataportal import (
+    DataportalClient,
+    DataportalDatasetInfo,
+)
+
+from ._helpers import FakeSession
+
+
+def package_payload(
+    *,
+    package_id: str = "pkg-1",
+    name: str = "steel-data",
+) -> dict[str, Any]:
+    return {
+        "id": package_id,
+        "name": name,
+        "title": "Steel data",
+        "notes": "Heat treatment measurements.",
+        "owner_org": "materials-org",
+        "private": False,
+        "type": "dataset",
+        "resources": [],
+    }
+
+
+class StubPackagesResource:
+    def __init__(self):
+        self.calls: list[tuple[Any, ...]] = []
+
+    def show(self, package: str) -> CkanPackageInfo:
+        self.calls.append(("show", package))
+        return CkanPackageInfo.from_dict(package_payload())
+
+    def search(self, query: str | None = None, **filters: Any) -> CkanPackageSearchResult:
+        self.calls.append(("search", query, filters))
+        return CkanPackageSearchResult.from_dict(
+            {"count": 1, "results": [package_payload()]}
+        )
+
+    def delete(self, package: str) -> None:
+        self.calls.append(("delete", package))
+
+
+def client_with_stub() -> tuple[DataportalClient, StubPackagesResource]:
+    client = DataportalClient(session=cast(Any, FakeSession()))
+    packages = StubPackagesResource()
+    client.packages = cast(Any, packages)
+    return client, packages
+
+
+class TestDatasetsResource(unittest.TestCase):
+    def test_show_delegates_to_packages_and_converts_result(self):
+        client, packages = client_with_stub()
+
+        dataset = client.datasets.show("steel-data")
+
+        self.assertIsInstance(dataset, DataportalDatasetInfo)
+        self.assertEqual(dataset.id, "pkg-1")
+        self.assertEqual(packages.calls, [("show", "steel-data")])
+
+    def test_show_accepts_dataset_model_and_uses_its_id(self):
+        client, packages = client_with_stub()
+        dataset = DataportalDatasetInfo.from_ckan(
+            CkanPackageInfo.from_dict(package_payload(package_id="pkg-2"))
+        )
+
+        _ = client.datasets.show(dataset)
+
+        self.assertEqual(packages.calls, [("show", "pkg-2")])
+
+    def test_search_delegates_query_and_filters(self):
+        client, packages = client_with_stub()
+
+        result = client.datasets.search("steel", rows=5, fq="private:false")
+
+        self.assertEqual(result.count, 1)
+        self.assertEqual(result.results[0].name, "steel-data")
+        self.assertEqual(
+            packages.calls,
+            [("search", "steel", {"rows": 5, "fq": "private:false"})],
+        )
+
+    def test_delete_delegates_dataset_id(self):
+        client, packages = client_with_stub()
+
+        result = client.datasets.delete("steel-data")
+
+        self.assertIsNone(result)
+        self.assertEqual(packages.calls, [("delete", "steel-data")])
+
+    def test_blank_dataset_id_is_rejected(self):
+        client, packages = client_with_stub()
+
+        with self.assertRaisesRegex(ValidationError, "dataset id must be non-empty"):
+            client.datasets.show(" ")
+
+        self.assertEqual(packages.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/dataportal/test_models.py
+++ b/tests/unit/services/dataportal/test_models.py
@@ -1,0 +1,95 @@
+import unittest
+from typing import Any
+
+from courier.exceptions import ValidationError
+from courier.services.ckan.models import CkanPackageInfo, CkanPackageSearchResult
+from courier.services.dataportal.models import (
+    DataportalDatasetInfo,
+    DataportalDatasetSearchResult,
+)
+
+
+def package_payload(
+    *,
+    package_id: str = "pkg-1",
+    name: str = "steel-data",
+) -> dict[str, Any]:
+    return {
+        "id": package_id,
+        "name": name,
+        "title": "Steel data",
+        "notes": "Heat treatment measurements.",
+        "owner_org": "materials-org",
+        "private": False,
+        "type": "dataset",
+        "resources": [{"id": "res-1", "name": "data.ttl"}],
+        "custom": "preserved",
+    }
+
+
+class TestDataportalDatasetInfo(unittest.TestCase):
+    def test_from_ckan_parses_dataset_fields_and_preserves_raw_payload(self):
+        package = CkanPackageInfo.from_dict(package_payload())
+
+        dataset = DataportalDatasetInfo.from_ckan(package)
+
+        self.assertEqual(dataset.id, "pkg-1")
+        self.assertEqual(dataset.name, "steel-data")
+        self.assertEqual(dataset.title, "Steel data")
+        self.assertEqual(dataset.notes, "Heat treatment measurements.")
+        self.assertEqual(dataset.owner_org, "materials-org")
+        self.assertFalse(dataset.private)
+        self.assertEqual(dataset.dataset_type, "dataset")
+        self.assertEqual(dataset.raw["custom"], "preserved")
+        self.assertEqual(dataset.raw["resources"][0]["id"], "res-1")
+
+    def test_optional_fields_default_to_none(self):
+        package = CkanPackageInfo.from_dict(
+            {
+                "id": "pkg-1",
+                "name": "steel-data",
+            }
+        )
+
+        dataset = DataportalDatasetInfo.from_ckan(package)
+
+        self.assertIsNone(dataset.title)
+        self.assertIsNone(dataset.notes)
+        self.assertIsNone(dataset.owner_org)
+        self.assertIsNone(dataset.private)
+        self.assertIsNone(dataset.dataset_type)
+
+    def test_string_private_value_is_parsed_without_truthiness_coercion(self):
+        payload = package_payload()
+        payload["private"] = "false"
+
+        dataset = DataportalDatasetInfo.from_ckan(CkanPackageInfo.from_dict(payload))
+
+        self.assertFalse(dataset.private)
+
+    def test_invalid_private_value_is_rejected(self):
+        payload = package_payload()
+        payload["private"] = "private"
+
+        with self.assertRaisesRegex(ValidationError, "private must be a boolean"):
+            DataportalDatasetInfo.from_ckan(CkanPackageInfo.from_dict(payload))
+
+
+class TestDataportalDatasetSearchResult(unittest.TestCase):
+    def test_from_ckan_converts_results_and_preserves_raw_payload(self):
+        raw = {
+            "count": 1,
+            "results": [package_payload()],
+            "search_facets": {"organization": {}},
+        }
+        result = CkanPackageSearchResult.from_dict(raw)
+
+        search = DataportalDatasetSearchResult.from_ckan(result)
+
+        self.assertEqual(search.count, 1)
+        self.assertEqual(search.results[0].name, "steel-data")
+        self.assertEqual(search.raw["search_facets"], {"organization": {}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/dataportal/test_models.py
+++ b/tests/unit/services/dataportal/test_models.py
@@ -86,11 +86,15 @@ class TestDataportalDatasetInfo(unittest.TestCase):
                 self.assertIs(dataset.private, expected)
 
     def test_invalid_private_value_is_rejected(self):
-        payload = package_payload()
-        payload["private"] = "private"
+        for value in ("private", 0.0, 1.0):
+            with (
+                self.subTest(value=value),
+                self.assertRaisesRegex(ValidationError, "private must be a boolean"),
+            ):
+                payload = package_payload()
+                payload["private"] = value
 
-        with self.assertRaisesRegex(ValidationError, "private must be a boolean"):
-            DataportalDatasetInfo.from_ckan(CkanPackageInfo.from_dict(payload))
+                DataportalDatasetInfo.from_ckan(CkanPackageInfo.from_dict(payload))
 
 
 class TestDataportalDatasetSearchResult(unittest.TestCase):

--- a/tests/unit/services/dataportal/test_models.py
+++ b/tests/unit/services/dataportal/test_models.py
@@ -67,6 +67,24 @@ class TestDataportalDatasetInfo(unittest.TestCase):
 
         self.assertFalse(dataset.private)
 
+    def test_supported_private_representations_are_parsed(self):
+        cases = [
+            (1, True),
+            (0, False),
+            (" true ", True),
+        ]
+
+        for value, expected in cases:
+            with self.subTest(value=value):
+                payload = package_payload()
+                payload["private"] = value
+
+                dataset = DataportalDatasetInfo.from_ckan(
+                    CkanPackageInfo.from_dict(payload)
+                )
+
+                self.assertIs(dataset.private, expected)
+
     def test_invalid_private_value_is_rejected(self):
         payload = package_payload()
         payload["private"] = "private"


### PR DESCRIPTION
This pull request exposes Dataportal-oriented dataset operations and models while delegating the underlying package actions to the internal CKAN layer. It establishes the operation boundary where generic publication metadata is wrapped by `DataportalMetadata` and serialized immediately before an API request.

## Summary

- Added `client.datasets` with create, show, search, patch, and delete methods.
- Added `DataportalDatasetInfo` and `DataportalDatasetSearchResult`.
- Parsed stable fields while preserving complete raw CKAN payloads.
- Accepted dataset identifiers as strings or dataset models.
- Accepted `DataportalMetadata` and raw mappings for create and patch.
- Serialized metadata immediately before CKAN delegation.
- Rejected plain `PublicationMetadata` with a targeted validation error.
- Kept publication metadata operation-scoped rather than client-scoped.
- Commits: `fac0a0d Add Dataportal dataset models`, `0b3ddc5 Add Dataportal dataset resource`, `6af4574 Add Dataportal dataset mutations`, and `5db3252 Format Dataportal dataset files`.

## Example

```python
from courier.metadata import Person, PublicationMetadata
from courier.services.dataportal import DataportalClient, DataportalMetadata

client = DataportalClient(api_token="secret")
publication = PublicationMetadata(
    title="Example dataset",
    description="Example description",
    creators=(Person(name="Example Author"),),
)
metadata = DataportalMetadata(metadata=publication)

dataset = client.datasets.create(metadata)
dataset = client.datasets.patch(dataset, {"private": False})
client.datasets.delete(dataset)
```

## Unit tests

- Dataset model parsing and raw-payload preservation.
- Dataset create, show, search, patch, and delete delegation.
- String and model identifier handling.
- Metadata serialization and raw mapping escape hatches.
- Plain `PublicationMetadata` rejection.
- Strict parsing of CKAN private values.

## Validation

- `black`
- `ruff check`
- `pytest`
- `mypy`