### PR TITLE
Dataportal Asset Resource

### DIFF
--- a/courier/services/ckan/resources.py
+++ b/courier/services/ckan/resources.py
@@ -82,6 +82,8 @@ class ResourcesResource:
         filename = path.name.strip()
         if not filename:
             raise ValidationError("upload filename must be non-empty")
+        if not path.is_file():
+            raise ValidationError(f"upload path must be a file: {path}")
         normalized_content_type = _optional_string(content_type, "content_type")
 
         with path.open("rb") as file:

--- a/courier/services/ckan/resources.py
+++ b/courier/services/ckan/resources.py
@@ -27,10 +27,17 @@ class ResourcesResource:
         payload: Mapping[str, Any],
         *,
         upload: UploadPath | None = None,
+        content_type: str | None = None,
     ) -> CkanResourceInfo:
         """Create a CKAN resource."""
         if upload is not None:
-            return self._create_with_upload(payload, upload)
+            return self._create_with_upload(
+                payload,
+                upload,
+                content_type=content_type,
+            )
+        if content_type is not None:
+            raise ValidationError("content_type requires an upload path")
         return CkanResourceInfo.from_dict(
             self.client.action.call("resource_create", payload)
         )
@@ -62,6 +69,8 @@ class ResourcesResource:
         self,
         payload: Mapping[str, Any],
         upload: UploadPath,
+        *,
+        content_type: str | None,
     ) -> CkanResourceInfo:
         data = dict(payload)
         if "upload" in data:
@@ -73,12 +82,18 @@ class ResourcesResource:
         filename = path.name.strip()
         if not filename:
             raise ValidationError("upload filename must be non-empty")
+        normalized_content_type = _optional_string(content_type, "content_type")
 
         with path.open("rb") as file:
+            upload_file: tuple[str, Any] | tuple[str, Any, str]
+            if normalized_content_type is None:
+                upload_file = (filename, file)
+            else:
+                upload_file = (filename, file, normalized_content_type)
             result = self.client.action.call(
                 "resource_create",
                 data,
-                files={"upload": (filename, file)},
+                files={"upload": upload_file},
             )
         return CkanResourceInfo.from_dict(result)
 
@@ -88,4 +103,13 @@ def _resource_id(resource: str | CkanResourceInfo) -> str:
     text = str(value).strip()
     if not text:
         raise ValidationError("resource id must be non-empty")
+    return text
+
+
+def _optional_string(value: str | None, field_name: str) -> str | None:
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        raise ValidationError(f"{field_name} must be non-empty")
     return text

--- a/courier/services/dataportal/__init__.py
+++ b/courier/services/dataportal/__init__.py
@@ -3,11 +3,13 @@
 from courier.services.dataportal.client import DataportalClient
 from courier.services.dataportal.metadata import DataportalMetadata
 from courier.services.dataportal.models import (
+    DataportalAssetInfo,
     DataportalDatasetInfo,
     DataportalDatasetSearchResult,
 )
 
 __all__ = [
+    "DataportalAssetInfo",
     "DataportalClient",
     "DataportalDatasetInfo",
     "DataportalDatasetSearchResult",

--- a/courier/services/dataportal/assets.py
+++ b/courier/services/dataportal/assets.py
@@ -79,6 +79,26 @@ class AssetsResource:
         _add_if_present(payload, "format", format)
         return DataportalAssetInfo.from_ckan(self.client.resources.create(payload))
 
+    def upload_rdf(
+        self,
+        dataset: str | DataportalDatasetInfo,
+        path: str | Path,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        format: str = "ttl",
+        content_type: str = "text/turtle",
+    ) -> DataportalAssetInfo:
+        """Upload an RDF file with conservative Turtle defaults."""
+        return self.upload(
+            dataset,
+            path,
+            name=name,
+            description=description,
+            format=format,
+            content_type=content_type,
+        )
+
     def show(self, asset: str | DataportalAssetInfo) -> DataportalAssetInfo:
         """Retrieve an asset by id or asset model."""
         return DataportalAssetInfo.from_ckan(

--- a/courier/services/dataportal/assets.py
+++ b/courier/services/dataportal/assets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
@@ -22,6 +23,42 @@ class AssetsResource:
     """Dataportal-facing asset operations."""
 
     client: DataportalClient
+
+    def upload(
+        self,
+        dataset: str | DataportalDatasetInfo,
+        path: str | Path,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        format: str | None = None,
+        content_type: str | None = None,
+    ) -> DataportalAssetInfo:
+        """Upload a local file as a Dataportal asset."""
+        upload_path = Path(path)
+        if not upload_path.is_file():
+            raise ValidationError(f"upload path must be a file: {upload_path}")
+
+        filename = _required_string(upload_path.name, "upload filename")
+        normalized_content_type = (
+            _required_string(content_type, "content_type")
+            if content_type is not None
+            else None
+        )
+        payload: dict[str, Any] = {
+            "package_id": _dataset_id(dataset),
+            "name": _required_string(name, "name") if name is not None else filename,
+        }
+        _add_if_present(payload, "description", description)
+        _add_if_present(payload, "format", format)
+        _add_if_present(payload, "mimetype", normalized_content_type)
+
+        resource = self.client.resources.create(
+            payload,
+            upload=upload_path,
+            content_type=normalized_content_type,
+        )
+        return DataportalAssetInfo.from_ckan(resource)
 
     def create_url(
         self,

--- a/courier/services/dataportal/assets.py
+++ b/courier/services/dataportal/assets.py
@@ -1,0 +1,94 @@
+"""Dataportal asset operations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+from courier.exceptions import ValidationError
+from courier.services.dataportal.models import (
+    DataportalAssetInfo,
+    DataportalDatasetInfo,
+)
+
+if TYPE_CHECKING:
+    from courier.services.dataportal.client import DataportalClient
+
+
+@dataclass
+class AssetsResource:
+    """Dataportal-facing asset operations."""
+
+    client: DataportalClient
+
+    def create_url(
+        self,
+        dataset: str | DataportalDatasetInfo,
+        *,
+        url: str,
+        name: str | None = None,
+        description: str | None = None,
+        format: str | None = None,
+    ) -> DataportalAssetInfo:
+        """Create an asset that references an external HTTP(S) URL."""
+        payload: dict[str, Any] = {
+            "package_id": _dataset_id(dataset),
+            "url": _absolute_http_url(url),
+        }
+        _add_if_present(payload, "name", name)
+        _add_if_present(payload, "description", description)
+        _add_if_present(payload, "format", format)
+        return DataportalAssetInfo.from_ckan(self.client.resources.create(payload))
+
+    def show(self, asset: str | DataportalAssetInfo) -> DataportalAssetInfo:
+        """Retrieve an asset by id or asset model."""
+        return DataportalAssetInfo.from_ckan(
+            self.client.resources.show(_asset_id(asset))
+        )
+
+    def patch(
+        self,
+        asset: str | DataportalAssetInfo,
+        payload: Mapping[str, Any],
+    ) -> DataportalAssetInfo:
+        """Partially update asset metadata."""
+        return DataportalAssetInfo.from_ckan(
+            self.client.resources.patch(_asset_id(asset), payload)
+        )
+
+    def delete(self, asset: str | DataportalAssetInfo) -> None:
+        """Delete an asset."""
+        self.client.resources.delete(_asset_id(asset))
+
+
+def _dataset_id(dataset: str | DataportalDatasetInfo) -> str:
+    if isinstance(dataset, DataportalDatasetInfo):
+        return dataset.id
+    return _required_string(dataset, "dataset id")
+
+
+def _asset_id(asset: str | DataportalAssetInfo) -> str:
+    if isinstance(asset, DataportalAssetInfo):
+        return asset.id
+    return _required_string(asset, "asset id")
+
+
+def _absolute_http_url(value: str) -> str:
+    url = _required_string(value, "url")
+    parts = urlsplit(url)
+    if parts.scheme.lower() not in {"http", "https"} or not parts.netloc:
+        raise ValidationError("url must be an absolute HTTP(S) URL")
+    return url
+
+
+def _required_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+def _add_if_present(data: dict[str, Any], key: str, value: str | None) -> None:
+    if value is not None:
+        data[key] = _required_string(value, key)

--- a/courier/services/dataportal/assets.py
+++ b/courier/services/dataportal/assets.py
@@ -142,7 +142,7 @@ def _absolute_http_url(value: str) -> str:
 
 def _required_string(value: object, field_name: str) -> str:
     if not isinstance(value, str) or not value.strip():
-        raise ValidationError(f"{field_name} must be a non-empty string")
+        raise ValidationError(f"{field_name} must be non-empty")
     return value.strip()
 
 

--- a/courier/services/dataportal/client.py
+++ b/courier/services/dataportal/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import requests
 
 from courier.services.ckan.client import CkanClient
+from courier.services.dataportal.assets import AssetsResource
 from courier.services.dataportal.datasets import DatasetsResource
 
 DEFAULT_DATAPORTAL_ADDRESS = "dataportal.material-digital.de"
@@ -31,4 +32,5 @@ class DataportalClient(CkanClient):
             timeout=timeout,
             session=session,
         )
+        self.assets = AssetsResource(self)
         self.datasets = DatasetsResource(self)

--- a/courier/services/dataportal/models.py
+++ b/courier/services/dataportal/models.py
@@ -6,7 +6,43 @@ from dataclasses import dataclass
 from typing import Any
 
 from courier.exceptions import ValidationError
-from courier.services.ckan.models import CkanPackageInfo, CkanPackageSearchResult
+from courier.services.ckan.models import (
+    CkanPackageInfo,
+    CkanPackageSearchResult,
+    CkanResourceInfo,
+)
+
+
+@dataclass(frozen=True)
+class DataportalAssetInfo:
+    """Important fields returned for a Dataportal asset."""
+
+    id: str
+    dataset_id: str | None
+    name: str | None
+    description: str | None
+    url: str | None
+    format: str | None
+    content_type: str | None
+    size: int | None
+    raw: dict[str, Any]
+
+    @classmethod
+    def from_ckan(cls, resource: CkanResourceInfo) -> DataportalAssetInfo:
+        """Build a Dataportal asset model from an internal CKAN model."""
+        return cls(
+            id=resource.id,
+            dataset_id=resource.package_id,
+            name=resource.name,
+            description=_optional_string(resource.raw.get("description")),
+            url=resource.url,
+            format=resource.format,
+            content_type=resource.mimetype,
+            size=_optional_int(
+                resource.raw.get("size", resource.raw.get("filesize"))
+            ),
+            raw=dict(resource.raw),
+        )
 
 
 @dataclass(frozen=True)
@@ -81,3 +117,22 @@ def _optional_bool(value: object) -> bool | None:
         if normalized == "false":
             return False
     raise ValidationError("private must be a boolean value")
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        raise ValidationError("asset size must be an integer")
+    if isinstance(value, int):
+        size = value
+    elif isinstance(value, str):
+        try:
+            size = int(value)
+        except ValueError as exc:
+            raise ValidationError("asset size must be an integer") from exc
+    else:
+        raise ValidationError("asset size must be an integer")
+    if size < 0:
+        raise ValidationError("asset size must be non-negative")
+    return size

--- a/courier/services/dataportal/models.py
+++ b/courier/services/dataportal/models.py
@@ -38,9 +38,7 @@ class DataportalAssetInfo:
             url=resource.url,
             format=resource.format,
             content_type=resource.mimetype,
-            size=_optional_int(
-                resource.raw.get("size", resource.raw.get("filesize"))
-            ),
+            size=_optional_int(resource.raw.get("size", resource.raw.get("filesize"))),
             raw=dict(resource.raw),
         )
 

--- a/tests/unit/services/ckan/test_resources.py
+++ b/tests/unit/services/ckan/test_resources.py
@@ -128,6 +128,50 @@ class TestResourcesResource(unittest.TestCase):
         ):
             client.resources.create({"package_id": "pkg-1"}, upload="")
 
+    def test_create_with_upload_sets_multipart_content_type(self):
+        session = FakeSession(
+            [FakeResponse(json_value={"success": True, "result": resource_payload()})]
+        )
+        client = CkanClient("ckan.test", session=cast(Any, session))
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "data.ttl"
+            path.write_text("@prefix x: <https://example.test/> .")
+
+            _ = client.resources.create(
+                {"package_id": "pkg-1"},
+                upload=path,
+                content_type="text/turtle",
+            )
+
+        upload = session.calls[0]["files"]["upload"]
+        self.assertEqual(upload[0], "data.ttl")
+        self.assertTrue(upload[1].closed)
+        self.assertEqual(upload[2], "text/turtle")
+
+    def test_content_type_requires_upload_path(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+
+        with self.assertRaisesRegex(ValidationError, "requires an upload path"):
+            client.resources.create(
+                {"package_id": "pkg-1", "url": "https://example.test/data.ttl"},
+                content_type="text/turtle",
+            )
+
+    def test_blank_upload_content_type_is_rejected(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "data.ttl"
+            path.write_text("@prefix x: <https://example.test/> .")
+
+            with self.assertRaisesRegex(ValidationError, "content_type"):
+                client.resources.create(
+                    {"package_id": "pkg-1"},
+                    upload=path,
+                    content_type=" ",
+                )
+
     def test_show_calls_resource_show_with_id(self):
         session = FakeSession(
             [FakeResponse(json_value={"success": True, "result": resource_payload()})]

--- a/tests/unit/services/ckan/test_resources.py
+++ b/tests/unit/services/ckan/test_resources.py
@@ -128,6 +128,19 @@ class TestResourcesResource(unittest.TestCase):
         ):
             client.resources.create({"package_id": "pkg-1"}, upload="")
 
+    def test_create_with_upload_rejects_non_file_path(self):
+        client = CkanClient("ckan.test", session=cast(Any, FakeSession()))
+
+        with TemporaryDirectory() as directory:
+            for path in (Path(directory), Path(directory) / "missing.ttl"):
+                with (
+                    self.subTest(path=path),
+                    self.assertRaisesRegex(
+                        ValidationError, "upload path must be a file"
+                    ),
+                ):
+                    client.resources.create({"package_id": "pkg-1"}, upload=path)
+
     def test_create_with_upload_sets_multipart_content_type(self):
         session = FakeSession(
             [FakeResponse(json_value={"success": True, "result": resource_payload()})]

--- a/tests/unit/services/dataportal/test_asset_models.py
+++ b/tests/unit/services/dataportal/test_asset_models.py
@@ -1,0 +1,74 @@
+import unittest
+from typing import Any
+
+from courier.exceptions import ValidationError
+from courier.services.ckan.models import CkanResourceInfo
+from courier.services.dataportal.models import DataportalAssetInfo
+
+
+def resource_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": "res-1",
+        "package_id": "pkg-1",
+        "name": "data.ttl",
+        "description": "RDF data.",
+        "url": "https://example.test/data.ttl",
+        "format": "ttl",
+        "mimetype": "text/turtle",
+        "size": 128,
+        "custom": "preserved",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestDataportalAssetInfo(unittest.TestCase):
+    def test_from_ckan_parses_asset_fields_and_preserves_raw_payload(self):
+        asset = DataportalAssetInfo.from_ckan(
+            CkanResourceInfo.from_dict(resource_payload())
+        )
+
+        self.assertEqual(asset.id, "res-1")
+        self.assertEqual(asset.dataset_id, "pkg-1")
+        self.assertEqual(asset.name, "data.ttl")
+        self.assertEqual(asset.description, "RDF data.")
+        self.assertEqual(asset.url, "https://example.test/data.ttl")
+        self.assertEqual(asset.format, "ttl")
+        self.assertEqual(asset.content_type, "text/turtle")
+        self.assertEqual(asset.size, 128)
+        self.assertEqual(asset.raw["custom"], "preserved")
+
+    def test_filesize_is_used_when_size_is_absent(self):
+        payload = resource_payload(filesize="42")
+        del payload["size"]
+
+        asset = DataportalAssetInfo.from_ckan(CkanResourceInfo.from_dict(payload))
+
+        self.assertEqual(asset.size, 42)
+
+    def test_optional_fields_default_to_none(self):
+        asset = DataportalAssetInfo.from_ckan(
+            CkanResourceInfo.from_dict({"id": "res-1"})
+        )
+
+        self.assertIsNone(asset.dataset_id)
+        self.assertIsNone(asset.name)
+        self.assertIsNone(asset.description)
+        self.assertIsNone(asset.url)
+        self.assertIsNone(asset.format)
+        self.assertIsNone(asset.content_type)
+        self.assertIsNone(asset.size)
+
+    def test_invalid_size_is_rejected(self):
+        for value in (True, "large", -1):
+            with (
+                self.subTest(value=value),
+                self.assertRaisesRegex(ValidationError, "asset size"),
+            ):
+                DataportalAssetInfo.from_ckan(
+                    CkanResourceInfo.from_dict(resource_payload(size=value))
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/dataportal/test_asset_models.py
+++ b/tests/unit/services/dataportal/test_asset_models.py
@@ -60,7 +60,7 @@ class TestDataportalAssetInfo(unittest.TestCase):
         self.assertIsNone(asset.size)
 
     def test_invalid_size_is_rejected(self):
-        for value in (True, "large", -1):
+        for value in (True, "large", 128.5, -1):
             with (
                 self.subTest(value=value),
                 self.assertRaisesRegex(ValidationError, "asset size"),

--- a/tests/unit/services/dataportal/test_assets.py
+++ b/tests/unit/services/dataportal/test_assets.py
@@ -1,0 +1,174 @@
+import unittest
+from typing import Any, cast
+
+from courier.exceptions import ValidationError
+from courier.services.ckan.models import CkanPackageInfo, CkanResourceInfo
+from courier.services.dataportal import (
+    DataportalAssetInfo,
+    DataportalClient,
+    DataportalDatasetInfo,
+)
+
+from ._helpers import FakeSession
+
+
+def resource_payload(
+    *,
+    resource_id: str = "res-1",
+    package_id: str = "pkg-1",
+) -> dict[str, Any]:
+    return {
+        "id": resource_id,
+        "package_id": package_id,
+        "name": "data.csv",
+        "description": "Measurements.",
+        "url": "https://example.test/data.csv",
+        "format": "csv",
+        "mimetype": "text/csv",
+    }
+
+
+class StubResourcesResource:
+    def __init__(self):
+        self.calls: list[tuple[Any, ...]] = []
+
+    def create(self, payload: dict[str, Any], **kwargs: Any) -> CkanResourceInfo:
+        self.calls.append(("create", payload, kwargs))
+        return CkanResourceInfo.from_dict(resource_payload())
+
+    def show(self, resource: str) -> CkanResourceInfo:
+        self.calls.append(("show", resource))
+        return CkanResourceInfo.from_dict(resource_payload())
+
+    def patch(
+        self,
+        resource: str,
+        payload: dict[str, Any],
+    ) -> CkanResourceInfo:
+        self.calls.append(("patch", resource, payload))
+        return CkanResourceInfo.from_dict(resource_payload())
+
+    def delete(self, resource: str) -> None:
+        self.calls.append(("delete", resource))
+
+
+def client_with_stub() -> tuple[DataportalClient, StubResourcesResource]:
+    client = DataportalClient(session=cast(Any, FakeSession()))
+    resources = StubResourcesResource()
+    client.resources = cast(Any, resources)
+    return client, resources
+
+
+class TestAssetsResource(unittest.TestCase):
+    def test_create_url_delegates_ckan_payload_and_converts_result(self):
+        client, resources = client_with_stub()
+
+        asset = client.assets.create_url(
+            "pkg-1",
+            url="https://example.test/data.csv",
+            name="data.csv",
+            description="Measurements.",
+            format="csv",
+        )
+
+        self.assertIsInstance(asset, DataportalAssetInfo)
+        self.assertEqual(asset.id, "res-1")
+        self.assertEqual(
+            resources.calls,
+            [
+                (
+                    "create",
+                    {
+                        "package_id": "pkg-1",
+                        "url": "https://example.test/data.csv",
+                        "name": "data.csv",
+                        "description": "Measurements.",
+                        "format": "csv",
+                    },
+                    {},
+                )
+            ],
+        )
+
+    def test_create_url_accepts_dataset_model(self):
+        client, resources = client_with_stub()
+        dataset = DataportalDatasetInfo.from_ckan(
+            CkanPackageInfo.from_dict({"id": "pkg-2", "name": "dataset"})
+        )
+
+        _ = client.assets.create_url(
+            dataset,
+            url="https://example.test/data.csv",
+        )
+
+        self.assertEqual(resources.calls[0][1]["package_id"], "pkg-2")
+
+    def test_create_url_rejects_non_http_absolute_urls(self):
+        client, resources = client_with_stub()
+
+        for url in ("data.csv", "/data.csv", "ftp://example.test/data.csv", " "):
+            with (
+                self.subTest(url=url),
+                self.assertRaisesRegex(ValidationError, "url"),
+            ):
+                client.assets.create_url("pkg-1", url=url)
+
+        self.assertEqual(resources.calls, [])
+
+    def test_create_url_rejects_blank_optional_fields(self):
+        client, resources = client_with_stub()
+
+        for field_name in ("name", "description", "format"):
+            with (
+                self.subTest(field_name=field_name),
+                self.assertRaisesRegex(ValidationError, field_name),
+            ):
+                client.assets.create_url(
+                    "pkg-1",
+                    url="https://example.test/data.csv",
+                    **{field_name: " "},
+                )
+
+        self.assertEqual(resources.calls, [])
+
+    def test_show_accepts_asset_model_and_uses_its_id(self):
+        client, resources = client_with_stub()
+        asset = DataportalAssetInfo.from_ckan(
+            CkanResourceInfo.from_dict(resource_payload(resource_id="res-2"))
+        )
+
+        result = client.assets.show(asset)
+
+        self.assertEqual(result.id, "res-1")
+        self.assertEqual(resources.calls, [("show", "res-2")])
+
+    def test_patch_delegates_raw_metadata_mapping(self):
+        client, resources = client_with_stub()
+        payload = {"name": "renamed.csv", "description": "Updated."}
+
+        asset = client.assets.patch("res-1", payload)
+
+        self.assertEqual(asset.id, "res-1")
+        self.assertEqual(resources.calls, [("patch", "res-1", payload)])
+
+    def test_delete_delegates_asset_id(self):
+        client, resources = client_with_stub()
+
+        result = client.assets.delete("res-1")
+
+        self.assertIsNone(result)
+        self.assertEqual(resources.calls, [("delete", "res-1")])
+
+    def test_blank_dataset_and_asset_ids_are_rejected(self):
+        client, resources = client_with_stub()
+
+        with self.assertRaisesRegex(ValidationError, "dataset id"):
+            client.assets.create_url(" ", url="https://example.test/data.csv")
+        with self.assertRaisesRegex(ValidationError, "asset id"):
+            client.assets.show(" ")
+
+        self.assertEqual(resources.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/dataportal/test_assets.py
+++ b/tests/unit/services/dataportal/test_assets.py
@@ -282,9 +282,15 @@ class TestAssetsResource(unittest.TestCase):
     def test_blank_dataset_and_asset_ids_are_rejected(self):
         client, resources = client_with_stub()
 
-        with self.assertRaisesRegex(ValidationError, "dataset id"):
+        with self.assertRaisesRegex(
+            ValidationError,
+            "dataset id must be non-empty",
+        ):
             client.assets.create_url(" ", url="https://example.test/data.csv")
-        with self.assertRaisesRegex(ValidationError, "asset id"):
+        with self.assertRaisesRegex(
+            ValidationError,
+            "asset id must be non-empty",
+        ):
             client.assets.show(" ")
 
         self.assertEqual(resources.calls, [])

--- a/tests/unit/services/dataportal/test_assets.py
+++ b/tests/unit/services/dataportal/test_assets.py
@@ -172,6 +172,44 @@ class TestAssetsResource(unittest.TestCase):
             ],
         )
 
+    def test_upload_rdf_uses_turtle_defaults(self):
+        client, resources = client_with_stub()
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "data.ttl"
+            path.write_text("@prefix x: <https://example.test/> .")
+
+            asset = client.assets.upload_rdf("pkg-1", path)
+
+        self.assertEqual(asset.id, "res-1")
+        self.assertEqual(resources.calls[0][1]["format"], "ttl")
+        self.assertEqual(resources.calls[0][1]["mimetype"], "text/turtle")
+        self.assertEqual(resources.calls[0][2]["content_type"], "text/turtle")
+
+    def test_upload_rdf_allows_format_and_content_type_overrides(self):
+        client, resources = client_with_stub()
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "data.rdf"
+            path.write_text("<rdf:RDF />")
+
+            _ = client.assets.upload_rdf(
+                "pkg-1",
+                path,
+                format="rdf",
+                content_type="application/rdf+xml",
+            )
+
+        self.assertEqual(resources.calls[0][1]["format"], "rdf")
+        self.assertEqual(
+            resources.calls[0][1]["mimetype"],
+            "application/rdf+xml",
+        )
+        self.assertEqual(
+            resources.calls[0][2]["content_type"],
+            "application/rdf+xml",
+        )
+
     def test_create_url_accepts_dataset_model(self):
         client, resources = client_with_stub()
         dataset = DataportalDatasetInfo.from_ckan(

--- a/tests/unit/services/dataportal/test_assets.py
+++ b/tests/unit/services/dataportal/test_assets.py
@@ -1,4 +1,6 @@
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, cast
 
 from courier.exceptions import ValidationError
@@ -60,6 +62,86 @@ def client_with_stub() -> tuple[DataportalClient, StubResourcesResource]:
 
 
 class TestAssetsResource(unittest.TestCase):
+    def test_upload_delegates_file_and_metadata(self):
+        client, resources = client_with_stub()
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "measurements.csv"
+            path.write_text("temperature,value\n300,1\n")
+
+            asset = client.assets.upload(
+                "pkg-1",
+                path,
+                name="data.csv",
+                description="Measurements.",
+                format="csv",
+                content_type="text/csv",
+            )
+
+        self.assertEqual(asset.id, "res-1")
+        self.assertEqual(
+            resources.calls,
+            [
+                (
+                    "create",
+                    {
+                        "package_id": "pkg-1",
+                        "name": "data.csv",
+                        "description": "Measurements.",
+                        "format": "csv",
+                        "mimetype": "text/csv",
+                    },
+                    {"upload": path, "content_type": "text/csv"},
+                )
+            ],
+        )
+
+    def test_upload_uses_filename_as_default_name(self):
+        client, resources = client_with_stub()
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "measurements.csv"
+            path.write_text("temperature,value\n300,1\n")
+
+            _ = client.assets.upload("pkg-1", path)
+
+        self.assertEqual(resources.calls[0][1]["name"], "measurements.csv")
+        self.assertEqual(
+            resources.calls[0][2],
+            {"upload": path, "content_type": None},
+        )
+
+    def test_upload_rejects_non_file_path(self):
+        client, resources = client_with_stub()
+
+        with (
+            TemporaryDirectory() as directory,
+            self.assertRaisesRegex(ValidationError, "must be a file"),
+        ):
+            client.assets.upload("pkg-1", directory)
+
+        self.assertEqual(resources.calls, [])
+
+    def test_upload_rejects_blank_optional_metadata(self):
+        client, resources = client_with_stub()
+
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "measurements.csv"
+            path.write_text("temperature,value\n300,1\n")
+
+            for field_name in ("name", "description", "format", "content_type"):
+                with (
+                    self.subTest(field_name=field_name),
+                    self.assertRaisesRegex(ValidationError, field_name),
+                ):
+                    client.assets.upload(
+                        "pkg-1",
+                        path,
+                        **{field_name: " "},
+                    )
+
+        self.assertEqual(resources.calls, [])
+
     def test_create_url_delegates_ckan_payload_and_converts_result(self):
         client, resources = client_with_stub()
 

--- a/tests/unit/services/dataportal/test_client.py
+++ b/tests/unit/services/dataportal/test_client.py
@@ -16,6 +16,7 @@ class TestDataportalClient(unittest.TestCase):
             client.base_url,
             "https://dataportal.material-digital.de",
         )
+        self.assertIs(client.assets.client, client)
         self.assertIs(client.action.client, client)
         self.assertIs(client.packages.client, client)
         self.assertIs(client.resources.client, client)


### PR DESCRIPTION
This pull request adds Dataportal-facing asset management for local file uploads, URL-backed resources, and RDF uploads. It presents a typed Dataportal model while preserving the complete CKAN resource payload for fields not yet modeled explicitly.

## Summary

- Added `client.assets` and `DataportalAssetInfo`.
- Added file upload, URL creation, show, patch, and delete operations.
- Added `upload_rdf(...)` with `ttl` and `text/turtle` defaults.
- Accepted dataset and asset identifiers as strings or Dataportal models.
- Added absolute HTTP(S) validation for URL-backed assets.
- Added file-path validation, filename-derived names, and multipart content types.
- Preserved complete raw CKAN resource payloads.
- Commits: `2fa9d52 Add Dataportal asset model`, `ea51402 Add Dataportal asset operations`, `c82aeb3 Add Dataportal file upload support`, `3cfc6a2 Add Dataportal RDF upload helper`, and `0fedc3b Format Dataportal asset model`.

## Example

```python
from courier.services.dataportal import DataportalClient

client = DataportalClient(api_token="secret")
asset = client.assets.upload_rdf(
    "dataset-name",
    "data.ttl",
    name="Knowledge graph",
)
client.assets.patch(asset, {"description": "Updated description"})
```

## Unit tests

- Asset model parsing and raw-payload preservation.
- File upload request construction and file lifecycle.
- RDF format and content-type defaults and overrides.
- URL validation and URL-backed resource creation.
- String and model identifier handling.
- Asset show, patch, and delete behavior.

## Validation

- `black`
- `ruff check`
- `pytest`
- `mypy`