### PR TITLE
DCAT RDF And SPARQL Queries

### DIFF
--- a/courier/services/dataportal/client.py
+++ b/courier/services/dataportal/client.py
@@ -7,6 +7,7 @@ import requests
 from courier.services.ckan.client import CkanClient
 from courier.services.dataportal.assets import AssetsResource
 from courier.services.dataportal.datasets import DatasetsResource
+from courier.services.dataportal.rdf import RdfResource
 
 DEFAULT_DATAPORTAL_ADDRESS = "dataportal.material-digital.de"
 
@@ -34,3 +35,4 @@ class DataportalClient(CkanClient):
         )
         self.assets = AssetsResource(self)
         self.datasets = DatasetsResource(self)
+        self.rdf = RdfResource(self)

--- a/courier/services/dataportal/client.py
+++ b/courier/services/dataportal/client.py
@@ -8,6 +8,7 @@ from courier.services.ckan.client import CkanClient
 from courier.services.dataportal.assets import AssetsResource
 from courier.services.dataportal.datasets import DatasetsResource
 from courier.services.dataportal.rdf import RdfResource
+from courier.services.dataportal.sparql import SparqlResource
 
 DEFAULT_DATAPORTAL_ADDRESS = "dataportal.material-digital.de"
 
@@ -36,3 +37,4 @@ class DataportalClient(CkanClient):
         self.assets = AssetsResource(self)
         self.datasets = DatasetsResource(self)
         self.rdf = RdfResource(self)
+        self.sparql = SparqlResource(self)

--- a/courier/services/dataportal/rdf.py
+++ b/courier/services/dataportal/rdf.py
@@ -60,7 +60,9 @@ def _dataset_id(dataset: str | DataportalDatasetInfo) -> str:
     return text
 
 
-def _rdf_format(format: str) -> str:
+def _rdf_format(format: object) -> str:
+    if not isinstance(format, str):
+        raise ValidationError("RDF format must be a string")
     value = format.strip().lower()
     if value not in _RDF_FORMATS:
         supported = ", ".join(sorted(_RDF_FORMATS))

--- a/courier/services/dataportal/rdf.py
+++ b/courier/services/dataportal/rdf.py
@@ -1,0 +1,70 @@
+"""DCAT RDF retrieval for Dataportal datasets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from courier.exceptions import ValidationError
+from courier.services.dataportal.models import DataportalDatasetInfo
+from courier.transport.url import join_url, quote_path_segment
+
+if TYPE_CHECKING:
+    from courier.services.dataportal.client import DataportalClient
+
+_RDF_FORMATS = {"jsonld", "n3", "rdf", "ttl", "xml"}
+
+
+@dataclass
+class RdfResource:
+    """Retrieve DCAT RDF representations of Dataportal datasets."""
+
+    client: DataportalClient
+
+    def dataset_url(
+        self,
+        dataset: str | DataportalDatasetInfo,
+        *,
+        format: str = "ttl",
+    ) -> str:
+        """Build the ckanext-dcat RDF URL for a dataset."""
+        dataset_id = _dataset_id(dataset)
+        rdf_format = _rdf_format(format)
+        return join_url(
+            self.client.base_url,
+            segments=[
+                "dataset",
+                quote_path_segment(
+                    f"{dataset_id}.{rdf_format}",
+                    field_name="dataset RDF path",
+                ),
+            ],
+        )
+
+    def dataset(
+        self,
+        dataset: str | DataportalDatasetInfo,
+        *,
+        format: str = "ttl",
+    ) -> str:
+        """Retrieve a dataset's DCAT RDF representation as text."""
+        return self.client.get_text(self.dataset_url(dataset, format=format))
+
+
+def _dataset_id(dataset: str | DataportalDatasetInfo) -> str:
+    if isinstance(dataset, DataportalDatasetInfo):
+        return dataset.id
+    text = str(dataset).strip()
+    if not text:
+        raise ValidationError("dataset id must be non-empty")
+    return text
+
+
+def _rdf_format(format: str) -> str:
+    value = format.strip().lower()
+    if value not in _RDF_FORMATS:
+        supported = ", ".join(sorted(_RDF_FORMATS))
+        raise ValidationError(
+            f"unsupported RDF format {format!r}; expected one of: {supported}"
+        )
+    return value

--- a/courier/services/dataportal/sparql.py
+++ b/courier/services/dataportal/sparql.py
@@ -1,0 +1,85 @@
+"""SPARQL endpoint discovery and querying for Dataportal datasets."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypeAlias
+from urllib.parse import urlsplit
+
+from courier.exceptions import ValidationError
+from courier.services.dataportal.models import (
+    DataportalAssetInfo,
+    DataportalDatasetInfo,
+)
+
+if TYPE_CHECKING:
+    from courier.services.dataportal.client import DataportalClient
+
+SparqlTarget: TypeAlias = str | DataportalDatasetInfo | DataportalAssetInfo
+
+
+@dataclass
+class SparqlResource:
+    """Dataportal-specific SPARQL operations."""
+
+    client: DataportalClient
+
+    def endpoint(self, target: SparqlTarget) -> str:
+        """Resolve an explicit or dataset-associated SPARQL endpoint URL."""
+        if isinstance(target, DataportalAssetInfo):
+            if target.url is None:
+                raise ValidationError("SPARQL asset does not include a URL")
+            return _absolute_http_url(target.url, field_name="SPARQL asset URL")
+
+        if isinstance(target, DataportalDatasetInfo):
+            return _dataset_endpoint(target)
+
+        value = _required_string(target, "SPARQL target")
+        if _is_absolute_http_url(value):
+            return value
+        if "://" in value:
+            raise ValidationError("SPARQL endpoint must be an absolute HTTP(S) URL")
+        return _dataset_endpoint(self.client.datasets.show(value))
+
+
+def _dataset_endpoint(dataset: DataportalDatasetInfo) -> str:
+    resources = dataset.raw.get("resources")
+    if not isinstance(resources, list):
+        raise ValidationError("dataset does not include resource metadata")
+
+    endpoints: list[str] = []
+    for resource in resources:
+        if not isinstance(resource, Mapping):
+            continue
+        format_value = resource.get("format")
+        if not isinstance(format_value, str) or format_value.strip().lower() != "sparql":
+            continue
+        url = resource.get("url")
+        if not isinstance(url, str):
+            raise ValidationError("SPARQL resource does not include a URL")
+        endpoints.append(_absolute_http_url(url, field_name="SPARQL resource URL"))
+
+    if not endpoints:
+        raise ValidationError("dataset does not include a SPARQL resource")
+    if len(endpoints) > 1:
+        raise ValidationError("dataset includes multiple SPARQL resources")
+    return endpoints[0]
+
+
+def _absolute_http_url(value: str, *, field_name: str) -> str:
+    url = _required_string(value, field_name)
+    if not _is_absolute_http_url(url):
+        raise ValidationError(f"{field_name} must be an absolute HTTP(S) URL")
+    return url
+
+
+def _is_absolute_http_url(value: str) -> bool:
+    parts = urlsplit(value)
+    return parts.scheme.lower() in {"http", "https"} and bool(parts.netloc)
+
+
+def _required_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{field_name} must be a non-empty string")
+    return value.strip()

--- a/courier/services/dataportal/sparql.py
+++ b/courier/services/dataportal/sparql.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 from urllib.parse import urlsplit
+
+import pandas as pd
+import requests
 
 from courier.exceptions import ValidationError
 from courier.services.dataportal.models import (
     DataportalAssetInfo,
     DataportalDatasetInfo,
 )
+from courier.transport.request import read_text
 
 if TYPE_CHECKING:
     from courier.services.dataportal.client import DataportalClient
@@ -41,6 +46,62 @@ class SparqlResource:
         if "://" in value:
             raise ValidationError("SPARQL endpoint must be an absolute HTTP(S) URL")
         return _dataset_endpoint(self.client.datasets.show(value))
+
+    def query_raw(
+        self,
+        target: SparqlTarget,
+        query: str,
+        *,
+        accept: str = "application/sparql-results+json",
+    ) -> str:
+        """Execute a SPARQL query and return the response body as text."""
+        query_text = _required_string(query, "query")
+        accept_value = _required_string(accept, "accept")
+        endpoint = self.endpoint(target)
+        params = {"query": query_text}
+        headers = {"Accept": accept_value}
+
+        if _same_origin(endpoint, self.client.base_url):
+            return self.client.get_text(endpoint, params=params, headers=headers)
+
+        response = requests.get(
+            endpoint,
+            params=params,
+            headers=headers,
+            timeout=self.client.timeout,
+            verify=self.client.verify,
+        )
+        return read_text(response)
+
+    def query_json(
+        self,
+        target: SparqlTarget,
+        query: str,
+    ) -> dict[str, Any]:
+        """Execute a SPARQL query and decode its JSON result."""
+        result = json.loads(
+            self.query_raw(
+                target,
+                query,
+                accept="application/sparql-results+json",
+            )
+        )
+        if not isinstance(result, dict):
+            raise ValidationError("SPARQL JSON response must be an object")
+        return result
+
+    def query_df(
+        self,
+        target: SparqlTarget,
+        query: str,
+        columns: list[str],
+    ) -> pd.DataFrame:
+        """Execute a SELECT query and return requested bindings as a DataFrame."""
+        normalized_columns = _columns(columns)
+        return _make_dataframe(
+            self.query_json(target, query),
+            normalized_columns,
+        )
 
 
 def _dataset_endpoint(dataset: DataportalDatasetInfo) -> str:
@@ -77,6 +138,54 @@ def _absolute_http_url(value: str, *, field_name: str) -> str:
 def _is_absolute_http_url(value: str) -> bool:
     parts = urlsplit(value)
     return parts.scheme.lower() in {"http", "https"} and bool(parts.netloc)
+
+
+def _same_origin(left: str, right: str) -> bool:
+    return _origin(left) == _origin(right)
+
+
+def _origin(value: str) -> tuple[str, str, int | None]:
+    parts = urlsplit(value)
+    scheme = parts.scheme.lower()
+    port = parts.port
+    if port is None:
+        port = 443 if scheme == "https" else 80 if scheme == "http" else None
+    return scheme, (parts.hostname or "").lower(), port
+
+
+def _columns(columns: list[str]) -> list[str]:
+    if (
+        not isinstance(columns, list)
+        or not columns
+        or any(
+            not isinstance(column, str) or not column.strip() for column in columns
+        )
+    ):
+        raise ValidationError("columns must be a non-empty list of strings")
+    return [column.strip() for column in columns]
+
+
+def _make_dataframe(
+    result: Mapping[str, Any],
+    columns: list[str],
+) -> pd.DataFrame:
+    raw_results = result.get("results")
+    if not isinstance(raw_results, Mapping):
+        raise ValidationError("SPARQL JSON response must include results")
+    raw_bindings = raw_results.get("bindings")
+    if not isinstance(raw_bindings, list):
+        raise ValidationError("SPARQL JSON response must include results.bindings")
+
+    rows: list[list[Any | None]] = []
+    for binding in raw_bindings:
+        if not isinstance(binding, Mapping):
+            raise ValidationError("SPARQL result bindings must be objects")
+        row: list[Any | None] = []
+        for column in columns:
+            value = binding.get(column)
+            row.append(value.get("value") if isinstance(value, Mapping) else None)
+        rows.append(row)
+    return pd.DataFrame(rows, columns=columns)
 
 
 def _required_string(value: object, field_name: str) -> str:

--- a/courier/services/dataportal/sparql.py
+++ b/courier/services/dataportal/sparql.py
@@ -114,7 +114,10 @@ def _dataset_endpoint(dataset: DataportalDatasetInfo) -> str:
         if not isinstance(resource, Mapping):
             continue
         format_value = resource.get("format")
-        if not isinstance(format_value, str) or format_value.strip().lower() != "sparql":
+        if (
+            not isinstance(format_value, str)
+            or format_value.strip().lower() != "sparql"
+        ):
             continue
         url = resource.get("url")
         if not isinstance(url, str):
@@ -157,9 +160,7 @@ def _columns(columns: list[str]) -> list[str]:
     if (
         not isinstance(columns, list)
         or not columns
-        or any(
-            not isinstance(column, str) or not column.strip() for column in columns
-        )
+        or any(not isinstance(column, str) or not column.strip() for column in columns)
     ):
         raise ValidationError("columns must be a non-empty list of strings")
     return [column.strip() for column in columns]

--- a/tests/unit/services/dataportal/_helpers.py
+++ b/tests/unit/services/dataportal/_helpers.py
@@ -12,12 +12,17 @@ class FakeResponse:
     def json(self) -> Any:
         return self._json_value
 
+    def raise_for_status(self) -> None:
+        return None
+
 
 class FakeSession:
     def __init__(self):
         self.headers: dict[str, str] = {}
         self.calls: list[dict[str, Any]] = []
+        self.response = FakeResponse()
 
     def request(self, method: str, url: str, **kwargs: Any) -> FakeResponse:
         self.calls.append({"method": method, "url": url, **kwargs})
-        return FakeResponse()
+        self.response.url = url
+        return self.response

--- a/tests/unit/services/dataportal/test_client.py
+++ b/tests/unit/services/dataportal/test_client.py
@@ -21,6 +21,7 @@ class TestDataportalClient(unittest.TestCase):
         self.assertIs(client.packages.client, client)
         self.assertIs(client.rdf.client, client)
         self.assertIs(client.resources.client, client)
+        self.assertIs(client.sparql.client, client)
         self.assertIs(client.datasets.client, client)
 
     def test_custom_address_and_default_scheme_are_supported(self):

--- a/tests/unit/services/dataportal/test_client.py
+++ b/tests/unit/services/dataportal/test_client.py
@@ -19,6 +19,7 @@ class TestDataportalClient(unittest.TestCase):
         self.assertIs(client.assets.client, client)
         self.assertIs(client.action.client, client)
         self.assertIs(client.packages.client, client)
+        self.assertIs(client.rdf.client, client)
         self.assertIs(client.resources.client, client)
         self.assertIs(client.datasets.client, client)
 

--- a/tests/unit/services/dataportal/test_rdf.py
+++ b/tests/unit/services/dataportal/test_rdf.py
@@ -1,0 +1,71 @@
+import unittest
+from typing import Any, cast
+
+from courier.exceptions import ValidationError
+from courier.services.ckan.models import CkanPackageInfo
+from courier.services.dataportal import DataportalClient, DataportalDatasetInfo
+
+from ._helpers import FakeResponse, FakeSession
+
+
+class TestRdfResource(unittest.TestCase):
+    def test_dataset_url_uses_dcat_endpoint_shape(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        url = client.rdf.dataset_url("steel data", format="TTL")
+
+        self.assertEqual(
+            url,
+            "https://dataportal.material-digital.de/dataset/steel%20data.ttl",
+        )
+
+    def test_dataset_url_accepts_dataset_model_and_uses_id(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        dataset = DataportalDatasetInfo.from_ckan(
+            CkanPackageInfo.from_dict({"id": "pkg-1", "name": "steel-data"})
+        )
+
+        url = client.rdf.dataset_url(dataset, format="jsonld")
+
+        self.assertEqual(
+            url,
+            "https://dataportal.material-digital.de/dataset/pkg-1.jsonld",
+        )
+
+    def test_supported_formats_are_accepted(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        for format in ("ttl", "rdf", "xml", "jsonld", "n3"):
+            with self.subTest(format=format):
+                self.assertTrue(
+                    client.rdf.dataset_url("pkg-1", format=format).endswith(
+                        f".{format}"
+                    )
+                )
+
+    def test_invalid_dataset_and_format_are_rejected(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        with self.assertRaisesRegex(ValidationError, "dataset id"):
+            client.rdf.dataset_url(" ")
+        with self.assertRaisesRegex(ValidationError, "unsupported RDF format"):
+            client.rdf.dataset_url("pkg-1", format="csv")
+
+    def test_dataset_retrieves_text_from_generated_url(self):
+        session = FakeSession()
+        session.response = FakeResponse()
+        session.response.text = "@prefix dcat: <http://www.w3.org/ns/dcat#> ."
+        client = DataportalClient(session=cast(Any, session))
+
+        text = client.rdf.dataset("pkg-1", format="ttl")
+
+        self.assertEqual(text, "@prefix dcat: <http://www.w3.org/ns/dcat#> .")
+        self.assertEqual(session.calls[0]["method"], "GET")
+        self.assertEqual(
+            session.calls[0]["url"],
+            "https://dataportal.material-digital.de/dataset/pkg-1.ttl",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/services/dataportal/test_rdf.py
+++ b/tests/unit/services/dataportal/test_rdf.py
@@ -51,6 +51,16 @@ class TestRdfResource(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "unsupported RDF format"):
             client.rdf.dataset_url("pkg-1", format="csv")
 
+    def test_non_string_format_is_rejected(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        for format in (None, 1, []):
+            with (
+                self.subTest(format=format),
+                self.assertRaisesRegex(ValidationError, "RDF format must be a string"),
+            ):
+                client.rdf.dataset_url("pkg-1", format=cast(Any, format))
+
     def test_dataset_retrieves_text_from_generated_url(self):
         session = FakeSession()
         session.response = FakeResponse()

--- a/tests/unit/services/dataportal/test_sparql.py
+++ b/tests/unit/services/dataportal/test_sparql.py
@@ -81,6 +81,7 @@ class TestSparqlEndpointDiscovery(unittest.TestCase):
         client = DataportalClient(session=cast(Any, FakeSession()))
         dataset = dataset_info(
             [
+                "invalid resource",
                 {"id": "res-1", "format": "ttl", "url": "https://example.test/data"},
                 {
                     "id": "res-2",

--- a/tests/unit/services/dataportal/test_sparql.py
+++ b/tests/unit/services/dataportal/test_sparql.py
@@ -152,6 +152,13 @@ class TestSparqlEndpointDiscovery(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "multiple SPARQL"):
             client.sparql.endpoint(dataset)
 
+    def test_sparql_resource_without_url_is_rejected(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        dataset = dataset_info([{"id": "res-1", "format": "SPARQL"}])
+
+        with self.assertRaisesRegex(ValidationError, "does not include a URL"):
+            client.sparql.endpoint(dataset)
+
     def test_invalid_sparql_resource_url_is_rejected(self):
         client = DataportalClient(session=cast(Any, FakeSession()))
         dataset = dataset_info(

--- a/tests/unit/services/dataportal/test_sparql.py
+++ b/tests/unit/services/dataportal/test_sparql.py
@@ -1,5 +1,9 @@
 import unittest
 from typing import Any, cast
+from unittest import mock
+
+import pandas as pd
+import pandas.testing as pdt
 
 from courier.exceptions import ValidationError
 from courier.services.ckan.models import CkanPackageInfo, CkanResourceInfo
@@ -9,7 +13,7 @@ from courier.services.dataportal import (
     DataportalDatasetInfo,
 )
 
-from ._helpers import FakeSession
+from ._helpers import FakeResponse, FakeSession
 
 
 def dataset_info(resources: object) -> DataportalDatasetInfo:
@@ -161,6 +165,186 @@ class TestSparqlEndpointDiscovery(unittest.TestCase):
 
         with self.assertRaisesRegex(ValidationError, "SPARQL target"):
             client.sparql.endpoint(" ")
+
+
+class TestSparqlQueries(unittest.TestCase):
+    def test_query_raw_uses_client_session_for_same_origin_endpoint(self):
+        session = FakeSession()
+        session.response.text = '{"results":{"bindings":[]}}'
+        client = DataportalClient(
+            api_token="secret",
+            session=cast(Any, session),
+        )
+
+        text = client.sparql.query_raw(
+            "https://dataportal.material-digital.de/fuseki/query",
+            " SELECT * WHERE { ?s ?p ?o } ",
+        )
+
+        self.assertEqual(text, '{"results":{"bindings":[]}}')
+        self.assertEqual(session.calls[0]["method"], "GET")
+        self.assertEqual(
+            session.calls[0]["params"],
+            {"query": "SELECT * WHERE { ?s ?p ?o }"},
+        )
+        self.assertEqual(
+            session.calls[0]["headers"],
+            {"Accept": "application/sparql-results+json"},
+        )
+        self.assertEqual(session.headers["Authorization"], "secret")
+
+    def test_query_raw_uses_unauthenticated_request_for_cross_origin_endpoint(self):
+        session = FakeSession()
+        client = DataportalClient(
+            api_token="secret",
+            verify=False,
+            timeout=12,
+            session=cast(Any, session),
+        )
+        response = FakeResponse()
+        response.text = "external result"
+
+        with mock.patch(
+            "courier.services.dataportal.sparql.requests.get",
+            return_value=response,
+        ) as get:
+            text = client.sparql.query_raw(
+                "https://query.example.test/sparql",
+                "ASK {}",
+                accept="text/plain",
+            )
+
+        self.assertEqual(text, "external result")
+        self.assertEqual(session.calls, [])
+        get.assert_called_once_with(
+            "https://query.example.test/sparql",
+            params={"query": "ASK {}"},
+            headers={"Accept": "text/plain"},
+            timeout=12.0,
+            verify=False,
+        )
+        self.assertNotIn("Authorization", get.call_args.kwargs["headers"])
+
+    def test_query_raw_validates_query_and_accept_before_request(self):
+        session = FakeSession()
+        client = DataportalClient(session=cast(Any, session))
+
+        with self.assertRaisesRegex(ValidationError, "query"):
+            client.sparql.query_raw(
+                "https://query.example.test/sparql",
+                " ",
+            )
+        with self.assertRaisesRegex(ValidationError, "accept"):
+            client.sparql.query_raw(
+                "https://query.example.test/sparql",
+                "ASK {}",
+                accept=" ",
+            )
+
+        self.assertEqual(session.calls, [])
+
+    def test_query_json_decodes_object_response(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        result = {"boolean": True}
+
+        with mock.patch.object(
+            client.sparql,
+            "query_raw",
+            return_value='{"boolean": true}',
+        ) as query_raw:
+            actual = client.sparql.query_json(
+                "https://query.example.test/sparql",
+                "ASK {}",
+            )
+
+        self.assertEqual(actual, result)
+        query_raw.assert_called_once_with(
+            "https://query.example.test/sparql",
+            "ASK {}",
+            accept="application/sparql-results+json",
+        )
+
+    def test_query_json_rejects_non_object_json(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        with (
+            mock.patch.object(client.sparql, "query_raw", return_value="[]"),
+            self.assertRaisesRegex(ValidationError, "must be an object"),
+        ):
+            client.sparql.query_json(
+                "https://query.example.test/sparql",
+                "SELECT * WHERE {}",
+            )
+
+    def test_query_json_propagates_json_decode_error(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        with (
+            mock.patch.object(client.sparql, "query_raw", return_value="not json"),
+            self.assertRaises(ValueError),
+        ):
+            client.sparql.query_json(
+                "https://query.example.test/sparql",
+                "SELECT * WHERE {}",
+            )
+
+    def test_query_df_preserves_columns_and_maps_unbound_values_to_none(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        result = {
+            "head": {"vars": ["a", "b"]},
+            "results": {
+                "bindings": [
+                    {"b": {"value": "2"}, "a": {"value": "1"}},
+                    {"a": {"value": "3"}},
+                ]
+            },
+        }
+
+        with mock.patch.object(client.sparql, "query_json", return_value=result):
+            frame = client.sparql.query_df(
+                "https://query.example.test/sparql",
+                "SELECT ?a ?b WHERE {}",
+                ["a", "b"],
+            )
+
+        expected = pd.DataFrame([["1", "2"], ["3", None]], columns=["a", "b"])
+        pdt.assert_frame_equal(frame, expected)
+
+    def test_query_df_validates_columns_before_query(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        for columns in ([], ["a", " "], cast(Any, ("a",))):
+            with (
+                self.subTest(columns=columns),
+                mock.patch.object(client.sparql, "query_json") as query_json,
+                self.assertRaisesRegex(ValidationError, "columns"),
+            ):
+                client.sparql.query_df(
+                    "https://query.example.test/sparql",
+                    "SELECT ?a WHERE {}",
+                    columns,
+                )
+            query_json.assert_not_called()
+
+    def test_query_df_rejects_malformed_sparql_results(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        cases = [
+            ({}, "include results"),
+            ({"results": {}}, "results.bindings"),
+            ({"results": {"bindings": ["invalid"]}}, "bindings must be objects"),
+        ]
+
+        for result, message in cases:
+            with (
+                self.subTest(result=result),
+                mock.patch.object(client.sparql, "query_json", return_value=result),
+                self.assertRaisesRegex(ValidationError, message),
+            ):
+                client.sparql.query_df(
+                    "https://query.example.test/sparql",
+                    "SELECT ?a WHERE {}",
+                    ["a"],
+                )
 
 
 if __name__ == "__main__":

--- a/tests/unit/services/dataportal/test_sparql.py
+++ b/tests/unit/services/dataportal/test_sparql.py
@@ -1,0 +1,167 @@
+import unittest
+from typing import Any, cast
+
+from courier.exceptions import ValidationError
+from courier.services.ckan.models import CkanPackageInfo, CkanResourceInfo
+from courier.services.dataportal import (
+    DataportalAssetInfo,
+    DataportalClient,
+    DataportalDatasetInfo,
+)
+
+from ._helpers import FakeSession
+
+
+def dataset_info(resources: object) -> DataportalDatasetInfo:
+    return DataportalDatasetInfo.from_ckan(
+        CkanPackageInfo.from_dict(
+            {
+                "id": "pkg-1",
+                "name": "steel-data",
+                "resources": resources,
+            }
+        )
+    )
+
+
+class StubDatasetsResource:
+    def __init__(self, dataset: DataportalDatasetInfo):
+        self.dataset = dataset
+        self.calls: list[str] = []
+
+    def show(self, dataset: str) -> DataportalDatasetInfo:
+        self.calls.append(dataset)
+        return self.dataset
+
+
+class TestSparqlEndpointDiscovery(unittest.TestCase):
+    def test_absolute_http_url_is_used_directly(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        endpoint = client.sparql.endpoint("https://query.example.test/sparql")
+
+        self.assertEqual(endpoint, "https://query.example.test/sparql")
+
+    def test_non_http_url_is_rejected_instead_of_treated_as_dataset(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        with self.assertRaisesRegex(ValidationError, "absolute HTTP"):
+            client.sparql.endpoint("ftp://query.example.test/sparql")
+
+    def test_asset_url_is_used(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        asset = DataportalAssetInfo.from_ckan(
+            CkanResourceInfo.from_dict(
+                {
+                    "id": "res-1",
+                    "url": "https://query.example.test/sparql",
+                    "format": "SPARQL",
+                }
+            )
+        )
+
+        endpoint = client.sparql.endpoint(asset)
+
+        self.assertEqual(endpoint, "https://query.example.test/sparql")
+
+    def test_asset_without_url_is_rejected(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        asset = DataportalAssetInfo.from_ckan(
+            CkanResourceInfo.from_dict({"id": "res-1", "format": "SPARQL"})
+        )
+
+        with self.assertRaisesRegex(ValidationError, "does not include a URL"):
+            client.sparql.endpoint(asset)
+
+    def test_dataset_model_discovers_single_sparql_resource(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        dataset = dataset_info(
+            [
+                {"id": "res-1", "format": "ttl", "url": "https://example.test/data"},
+                {
+                    "id": "res-2",
+                    "format": "SPARQL",
+                    "url": "https://query.example.test/sparql",
+                },
+            ]
+        )
+
+        endpoint = client.sparql.endpoint(dataset)
+
+        self.assertEqual(endpoint, "https://query.example.test/sparql")
+
+    def test_dataset_identifier_is_loaded_before_discovery(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        datasets = StubDatasetsResource(
+            dataset_info(
+                [
+                    {
+                        "id": "res-2",
+                        "format": "sparql",
+                        "url": "https://query.example.test/sparql",
+                    }
+                ]
+            )
+        )
+        client.datasets = cast(Any, datasets)
+
+        endpoint = client.sparql.endpoint("steel-data")
+
+        self.assertEqual(endpoint, "https://query.example.test/sparql")
+        self.assertEqual(datasets.calls, ["steel-data"])
+
+    def test_missing_resource_metadata_is_rejected(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        dataset = dataset_info([])
+        dataset.raw.pop("resources")
+
+        with self.assertRaisesRegex(ValidationError, "resource metadata"):
+            client.sparql.endpoint(dataset)
+
+    def test_missing_sparql_resource_is_rejected(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        dataset = dataset_info(
+            [{"id": "res-1", "format": "ttl", "url": "https://example.test/data"}]
+        )
+
+        with self.assertRaisesRegex(ValidationError, "does not include a SPARQL"):
+            client.sparql.endpoint(dataset)
+
+    def test_multiple_sparql_resources_are_rejected(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        dataset = dataset_info(
+            [
+                {
+                    "id": "res-1",
+                    "format": "SPARQL",
+                    "url": "https://query.example.test/one",
+                },
+                {
+                    "id": "res-2",
+                    "format": "sparql",
+                    "url": "https://query.example.test/two",
+                },
+            ]
+        )
+
+        with self.assertRaisesRegex(ValidationError, "multiple SPARQL"):
+            client.sparql.endpoint(dataset)
+
+    def test_invalid_sparql_resource_url_is_rejected(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+        dataset = dataset_info(
+            [{"id": "res-1", "format": "SPARQL", "url": "/fuseki/query"}]
+        )
+
+        with self.assertRaisesRegex(ValidationError, "absolute HTTP"):
+            client.sparql.endpoint(dataset)
+
+    def test_blank_target_is_rejected(self):
+        client = DataportalClient(session=cast(Any, FakeSession()))
+
+        with self.assertRaisesRegex(ValidationError, "SPARQL target"):
+            client.sparql.endpoint(" ")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request adds DCAT dataset-metadata retrieval together with Dataportal-specific SPARQL endpoint discovery and query helpers. It supports the current Dataportal workflow without prematurely extracting a shared abstraction from the independently evolving Dataportal and Ontodocker SPARQL implementations.

## Summary

- Added `client.rdf.dataset_url(...)` and `client.rdf.dataset(...)`.
- Supported `ttl`, `rdf`, `xml`, `jsonld`, and `n3` DCAT formats.
- Added SPARQL endpoint, raw response, JSON, and DataFrame helpers.
- Resolved endpoints from explicit URLs, assets, or exactly one dataset resource marked with `format="SPARQL"`.
- Rejected missing, ambiguous, unsupported, and invalid endpoints.
- Reused the configured session for same-origin queries.
- Prevented CKAN token leakage by querying cross-origin endpoints without the CKAN `Authorization` header.
- Represented unbound SPARQL values as `None` in DataFrames.
- Commits: `a018846 Add Dataportal DCAT RDF retrieval`, `8bfd84b Add Dataportal SPARQL endpoint discovery`, `fce972e Add Dataportal SPARQL query helpers`, and `e29aa22 Format Dataportal SPARQL helpers`.

## Example

```python
from courier.services.dataportal import DataportalClient

client = DataportalClient(api_token="secret")
query = "SELECT ?subject WHERE { ?subject ?predicate ?object } LIMIT 10"
frame = client.sparql.query_df(
    "dataset-name",
    query,
    columns=["subject"],
)
```

## Unit tests

- DCAT dataset URL construction, identifier quoting, and format validation.
- Explicit, asset-based, and dataset-resource endpoint discovery.
- Missing and ambiguous endpoint handling.
- SPARQL query parameters and `Accept` headers.
- Same-origin session reuse and cross-origin authorization isolation.
- JSON parsing, DataFrame column ordering, unbound values, and malformed results.

## Validation

- `black`
- `ruff check`
- `pytest`
- `mypy