### PR TITLE
Align public service client exports

### DIFF
--- a/courier/__init__.py
+++ b/courier/__init__.py
@@ -9,11 +9,13 @@ except importlib.metadata.PackageNotFoundError:
 
 from courier.http_client import HttpClient
 from courier.metadata import Contributor, Person, PublicationMetadata, RelatedIdentifier
+from courier.services.dataportal import DataportalClient
 from courier.services.ontodocker import OntodockerClient
 from courier.services.zenodo import ZenodoClient
 
 __all__ = [
     "Contributor",
+    "DataportalClient",
     "HttpClient",
     "OntodockerClient",
     "Person",

--- a/courier/services/__init__.py
+++ b/courier/services/__init__.py
@@ -1,3 +1,5 @@
+from courier.services.dataportal import DataportalClient
 from courier.services.ontodocker import OntodockerClient
+from courier.services.zenodo import ZenodoClient
 
-__all__ = ["OntodockerClient"]
+__all__ = ["DataportalClient", "OntodockerClient", "ZenodoClient"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -207,7 +207,7 @@ compatible address to be supplied explicitly.
 A `DataportalClient` exposes four resource objects:
 
 ```python
-from courier.services.dataportal import DataportalClient
+from courier import DataportalClient
 
 client = DataportalClient(api_token="your-token")
 
@@ -234,7 +234,7 @@ Create a client:
 ```python
 import os
 
-from courier.services.dataportal import DataportalClient
+from courier import DataportalClient
 
 client = DataportalClient(api_token=os.environ["DATAPORTAL_TOKEN"])
 ```

--- a/notebooks/DataportalClient.ipynb
+++ b/notebooks/DataportalClient.ipynb
@@ -72,8 +72,8 @@
     }
    ],
    "source": [
-    "from courier.metadata import Person, PublicationMetadata\n",
-    "from courier.services.dataportal import DataportalClient, DataportalMetadata\n",
+    "from courier import DataportalClient, Person, PublicationMetadata\n",
+    "from courier.services.dataportal import DataportalMetadata\n",
     "\n",
     "client = DataportalClient(api_token=token)\n",
     "client.base_url"

--- a/tests/unit/services/dataportal/test_client.py
+++ b/tests/unit/services/dataportal/test_client.py
@@ -44,8 +44,8 @@ class TestDataportalClient(unittest.TestCase):
         self.assertEqual(client.api_token, "token")
         self.assertEqual(session.headers["Authorization"], "token")
 
-    def test_client_is_not_exported_from_top_level_package(self):
-        self.assertFalse(hasattr(courier, "DataportalClient"))
+    def test_is_exported_from_top_level_package(self):
+        self.assertIs(courier.DataportalClient, DataportalClient)
 
     def test_client_construction_does_not_accept_publication_metadata(self):
         metadata = PublicationMetadata(

--- a/tests/unit/test_tests.py
+++ b/tests/unit/test_tests.py
@@ -5,6 +5,10 @@ from unittest import mock
 
 import courier
 import courier.metadata as metadata_models
+import courier.services as services
+from courier.services.dataportal import DataportalClient
+from courier.services.ontodocker import OntodockerClient
+from courier.services.zenodo import ZenodoClient
 
 
 class TestVersion(unittest.TestCase):
@@ -32,6 +36,16 @@ class TestVersion(unittest.TestCase):
 
 
 class TestPublicApi(unittest.TestCase):
+    def test_service_clients_are_top_level_imports(self):
+        self.assertIs(courier.DataportalClient, DataportalClient)
+        self.assertIs(courier.OntodockerClient, OntodockerClient)
+        self.assertIs(courier.ZenodoClient, ZenodoClient)
+
+    def test_service_clients_are_services_imports(self):
+        self.assertIs(services.DataportalClient, DataportalClient)
+        self.assertIs(services.OntodockerClient, OntodockerClient)
+        self.assertIs(services.ZenodoClient, ZenodoClient)
+
     def test_publication_metadata_models_are_top_level_imports(self):
         self.assertIs(courier.Contributor, metadata_models.Contributor)
         self.assertIs(courier.Person, metadata_models.Person)


### PR DESCRIPTION
This pull request aligns the public API for all service clients. `DataportalClient`, `OntodockerClient`, and `ZenodoClient` can now be imported consistently from both `courier` and `courier.services`.

## Summary

- Exposes `DataportalClient` from the top-level package.
- Exposes all service clients from `courier.services`.
- Keeps service-specific metadata, models, and exceptions in their respective service packages.
- Adds public API contract tests.
- Updates Dataportal `README` examples and notebook imports to use the aligned API.
- Preserves all existing service-specific import paths.

## Unit Tests

- Verifies that all service clients resolve to the same classes from `courier`, `courier.services`, and their service packages.
- Retains coverage of the boundary excluding `DataportalMetadata` from the top-level API.

## Validation

- `pytest -q`
- `ruff check`
- `mypy courier`
- README doctests
- 100% patch and project coverage