### PR TITLE
Accept Path objects for Ontodocker Turtle uploads

### DIFF
--- a/courier/services/ontodocker/datasets.py
+++ b/courier/services/ontodocker/datasets.py
@@ -152,8 +152,10 @@ class DatasetsResource:
         PermissionError
             If `turtlefile` cannot be read.
         """
-        if isinstance(turtlefile, str) and not turtlefile.strip():
-            raise ValidationError("turtlefile must be a non-empty path")
+        if isinstance(turtlefile, str):
+            turtlefile = turtlefile.strip()
+            if not turtlefile:
+                raise ValidationError("turtlefile must be a non-empty path")
         path = Path(turtlefile)
         url = self._dataset_url(name)
 

--- a/courier/services/ontodocker/datasets.py
+++ b/courier/services/ontodocker/datasets.py
@@ -128,7 +128,7 @@ class DatasetsResource:
         _ = path.write_text(content, encoding="utf-8")
         return path
 
-    def upload_turtlefile(self, name: str, turtlefile: str) -> str:
+    def upload_turtlefile(self, name: str, turtlefile: str | Path) -> str:
         """Upload a Turtle (.ttl) file into an existing dataset.
 
         Parameters
@@ -152,12 +152,12 @@ class DatasetsResource:
         PermissionError
             If `turtlefile` cannot be read.
         """
-        turtlefile = turtlefile.strip()
-        if not turtlefile:
+        if isinstance(turtlefile, str) and not turtlefile.strip():
             raise ValidationError("turtlefile must be a non-empty path")
+        path = Path(turtlefile)
         url = self._dataset_url(name)
 
-        with open(turtlefile, "rb") as f:
+        with path.open("rb") as f:
             return self.client.post_text(url, files={"file": f})
 
     def upload_graph(

--- a/tests/unit/test_ontodocker_client.py
+++ b/tests/unit/test_ontodocker_client.py
@@ -248,12 +248,12 @@ class TestDatasetsResource(unittest.TestCase):
                 with self.subTest(path_type=label):
                     out = c.datasets.upload_turtlefile("ds", value)
 
-                self.assertEqual(out, "ok")
-                self.assertEqual(s.calls[0]["method"], "POST")
-                self.assertEqual(
-                    s.calls[0]["url"], "https://example.org/api/v1/jena/ds"
-                )
-                self.assertIn("file", s.calls[0]["files"])
+                    self.assertEqual(out, "ok")
+                    self.assertEqual(s.calls[0]["method"], "POST")
+                    self.assertEqual(
+                        s.calls[0]["url"], "https://example.org/api/v1/jena/ds"
+                    )
+                    self.assertIn("file", s.calls[0]["files"])
 
     def test_upload_graph_validates_name(self):
         s = _FakeSession()

--- a/tests/unit/test_ontodocker_client.py
+++ b/tests/unit/test_ontodocker_client.py
@@ -229,21 +229,25 @@ class TestDatasetsResource(unittest.TestCase):
             with self.assertRaises(FileNotFoundError):
                 _ = c.datasets.upload_turtlefile("ds", str(missing))
 
-    def test_upload_turtlefile_uses_post_with_file_field(self):
-        s = _FakeSession()
-        s.response = _FakeResponse(text="ok", request=_FakeRequest("POST"))
-        c = OntodockerClient("https://example.org", session=s)
-
+    def test_upload_turtlefile_uses_post_with_file_field_for_str_and_path(self):
         with TemporaryDirectory() as tmp:
             turtlefile = Path(tmp) / "in.ttl"
             turtlefile.write_text("@prefix : <x> .", encoding="utf-8")
 
-            out = c.datasets.upload_turtlefile("ds", str(turtlefile))
+            for value in (str(turtlefile), turtlefile):
+                s = _FakeSession()
+                s.response = _FakeResponse(text="ok", request=_FakeRequest("POST"))
+                c = OntodockerClient("https://example.org", session=s)
 
-        self.assertEqual(out, "ok")
-        self.assertEqual(s.calls[0]["method"], "POST")
-        self.assertEqual(s.calls[0]["url"], "https://example.org/api/v1/jena/ds")
-        self.assertIn("file", s.calls[0]["files"])
+                with self.subTest(type=type(value).__name__):
+                    out = c.datasets.upload_turtlefile("ds", value)
+
+                self.assertEqual(out, "ok")
+                self.assertEqual(s.calls[0]["method"], "POST")
+                self.assertEqual(
+                    s.calls[0]["url"], "https://example.org/api/v1/jena/ds"
+                )
+                self.assertIn("file", s.calls[0]["files"])
 
     def test_upload_graph_validates_name(self):
         s = _FakeSession()

--- a/tests/unit/test_ontodocker_client.py
+++ b/tests/unit/test_ontodocker_client.py
@@ -234,12 +234,18 @@ class TestDatasetsResource(unittest.TestCase):
             turtlefile = Path(tmp) / "in.ttl"
             turtlefile.write_text("@prefix : <x> .", encoding="utf-8")
 
-            for value in (str(turtlefile), turtlefile):
+            cases = (
+                ("str", str(turtlefile)),
+                ("padded str", f" {turtlefile} "),
+                ("Path", turtlefile),
+            )
+
+            for label, value in cases:
                 s = _FakeSession()
                 s.response = _FakeResponse(text="ok", request=_FakeRequest("POST"))
                 c = OntodockerClient("https://example.org", session=s)
 
-                with self.subTest(type=type(value).__name__):
+                with self.subTest(path_type=label):
                     out = c.datasets.upload_turtlefile("ds", value)
 
                 self.assertEqual(out, "ok")


### PR DESCRIPTION
## Summary
- Allow `OntodockerClient.datasets.upload_turtlefile` to accept `pathlib.Path` directly in addition to `str`
- Normalize upload paths with `Path(...)` before opening the file
- Cover both string and `Path` upload inputs in unit tests