### PR TITLE
Map publication metadata to Dataportal schema fields

### DIFF
--- a/courier/services/dataportal/metadata.py
+++ b/courier/services/dataportal/metadata.py
@@ -85,6 +85,13 @@ class DataportalMetadata:
         _add_if_present(payload, "license_id", self.metadata.license)
         _add_if_present(payload, "version", self.metadata.version)
         _add_if_present(payload, "type", self.dataset_type)
+        payload["creator"] = [
+            _dataportal_agent(person) for person in self.metadata.creators
+        ]
+        if self.metadata.publication_date is not None:
+            payload["issued"] = self.metadata.publication_date.isoformat()
+        if self.metadata.language is not None:
+            payload["language"] = [self.metadata.language]
 
         if self.groups:
             payload["groups"] = [
@@ -154,6 +161,25 @@ def _generated_extra_keys(metadata: PublicationMetadata) -> set[str]:
     if metadata.related_identifiers:
         keys.add("related_identifiers")
     return keys
+
+
+def _dataportal_agent(person: Person) -> dict[str, str]:
+    data = {
+        "name": _person_name(person),
+        "type": "Person",
+    }
+    _add_if_present(data, "identifier", person.orcid)
+    return data
+
+
+def _person_name(person: Person) -> str:
+    if person.name:
+        return person.name
+    if person.family_name and person.given_names:
+        return f"{person.family_name}, {person.given_names}"
+    raise ValidationError(
+        "person requires either name or both family_name and given_names"
+    )
 
 
 def _person_dict(person: Person) -> dict[str, str]:

--- a/courier/services/dataportal/metadata.py
+++ b/courier/services/dataportal/metadata.py
@@ -164,6 +164,7 @@ def _generated_extra_keys(metadata: PublicationMetadata) -> set[str]:
 
 
 def _dataportal_agent(person: Person) -> dict[str, str]:
+    """Serialize a person into the Dataportal agent field shape."""
     data = {
         "name": _person_name(person),
         "type": "Person",
@@ -173,6 +174,7 @@ def _dataportal_agent(person: Person) -> dict[str, str]:
 
 
 def _person_name(person: Person) -> str:
+    """Return the display name used for Dataportal person fields."""
     if person.name:
         return person.name
     if person.family_name and person.given_names:

--- a/tests/unit/services/dataportal/test_datasets.py
+++ b/tests/unit/services/dataportal/test_datasets.py
@@ -100,6 +100,7 @@ class TestDatasetsResource(unittest.TestCase):
                         "owner_org": "materials-org",
                         "private": False,
                         "license_id": "CC-BY-4.0",
+                        "creator": [{"name": "Doe, Jane", "type": "Person"}],
                         "extras": [
                             {
                                 "key": "creators",

--- a/tests/unit/services/dataportal/test_metadata.py
+++ b/tests/unit/services/dataportal/test_metadata.py
@@ -10,6 +10,7 @@ from courier.metadata import (
     RelatedIdentifier,
 )
 from courier.services.dataportal import DataportalMetadata
+from courier.services.dataportal.metadata import _person_name
 
 
 def publication_metadata(**overrides: Any) -> PublicationMetadata:
@@ -81,6 +82,18 @@ class TestDataportalMetadata(unittest.TestCase):
         self.assertFalse(payload["private"])
         self.assertEqual(payload["groups"], [{"name": "heat-treatment"}])
         self.assertEqual(payload["type"], "dataset")
+        self.assertEqual(
+            payload["creator"],
+            [
+                {
+                    "identifier": "0000-0000-0000-0000",
+                    "name": "Doe, Jane",
+                    "type": "Person",
+                }
+            ],
+        )
+        self.assertEqual(payload["issued"], "2026-06-08")
+        self.assertEqual(payload["language"], ["eng"])
 
         extras = extras_by_key(payload)
         self.assertEqual(extras["pmd_profile"], "dataset-v1")
@@ -142,9 +155,44 @@ class TestDataportalMetadata(unittest.TestCase):
         extras = extras_by_key(payload)
 
         self.assertEqual(payload["tags"], [])
+        self.assertEqual(
+            payload["creator"],
+            [
+                {
+                    "identifier": "0000-0000-0000-0000",
+                    "name": "Doe, Jane",
+                    "type": "Person",
+                }
+            ],
+        )
         self.assertNotIn("license_id", payload)
         self.assertNotIn("version", payload)
+        self.assertNotIn("issued", payload)
+        self.assertNotIn("language", payload)
         self.assertEqual(set(extras), {"creators"})
+
+    def test_schema_creator_accepts_explicit_person_name(self):
+        publication = publication_metadata(
+            creators=[Person(name="Steel Research Group")],
+        )
+
+        payload = DataportalMetadata(metadata=publication).to_payload()
+
+        self.assertEqual(
+            payload["creator"],
+            [
+                {
+                    "name": "Steel Research Group",
+                    "type": "Person",
+                }
+            ],
+        )
+
+    def test_person_name_rejects_invalid_person_state(self):
+        person = object.__new__(Person)
+
+        with self.assertRaisesRegex(ValidationError, "person requires"):
+            _ = _person_name(person)
 
     def test_generated_extra_collision_is_rejected(self):
         with self.assertRaisesRegex(ValidationError, "publication_date"):


### PR DESCRIPTION
## Summary

Map selected `PublicationMetadata` fields to Dataportal/DCAT schema-backed package fields so they are visible to the Dataportal schema and GUI, while preserving the existing CKAN extras for backwards compatibility.

## Applied Changes

- Added `creator` to the Dataportal package payload from `PublicationMetadata.creators`
- Added `issued` from `PublicationMetadata.publication_date`
- Added `language` as a Dataportal multiple-text field from `PublicationMetadata.language`
- Kept existing `extras` serialization unchanged for compatibility
- Added helper docstrings for the new Dataportal metadata helper functions
- Added tests for schema-backed fields and existing extras
- Updated dataset-create delegation expectations for the expanded payload

## Example

```python
publication = PublicationMetadata(
    title="Example",
    description="Example description.",
    creators=(Person(name="Jane Doe", orcid="0000-0000-0000-0000"),),
    publication_date=date(2026, 7, 22),
    language="eng",
    license="CC-BY-4.0",
)

metadata = DataportalMetadata(
    metadata=publication,
    owner_org=owner_org,
    private=False,
)

payload = metadata.to_payload()
```

The payload now includes:

```python
{
    "creator": [
        {
            "name": "Jane Doe",
            "type": "Person",
            "identifier": "0000-0000-0000-0000",
        }
    ],
    "issued": "2026-07-22",
    "language": ["eng"],
}
```

The existing compatibility extras, such as `creators`, `publication_date`, and `language`, are still emitted.

## Validation

- `black`
- `ruff check`
- `pytest`
- `coverage`
- `mypy`

## Note
Merging this PR may close #84.