### PR TITLE
Add explicit Dataportal schema metadata fields

### DIFF
--- a/courier/services/dataportal/metadata.py
+++ b/courier/services/dataportal/metadata.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 import json
 import re
 import unicodedata
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from datetime import date
 from typing import Any
 
 from courier.exceptions import ValidationError
 from courier.metadata import Contributor, Person, PublicationMetadata, RelatedIdentifier
+
+_CONTACT_FIELDS = frozenset({"uri", "name", "email", "identifier", "url"})
+_PUBLISHER_FIELDS = frozenset(_CONTACT_FIELDS | {"type"})
 
 
 @dataclass
@@ -23,6 +28,10 @@ class DataportalMetadata:
     groups: list[str] = field(default_factory=list)
     extras: dict[str, str] = field(default_factory=dict)
     dataset_type: str | None = None
+    publisher: Mapping[str, str] | None = None
+    contact: list[Mapping[str, str]] = field(default_factory=list)
+    modified: date | str | None = None
+    identifier: str | None = None
 
     def __post_init__(self) -> None:
         self.validate()
@@ -38,6 +47,10 @@ class DataportalMetadata:
             _ = _required_string(self.owner_org, "owner_org")
         if self.dataset_type is not None:
             _ = _required_string(self.dataset_type, "dataset_type")
+        if self.modified is not None:
+            _ = _date_string(self.modified, "modified")
+        if self.identifier is not None:
+            _ = _required_string(self.identifier, "identifier")
         if self.private is not None and not isinstance(self.private, bool):
             raise ValidationError("private must be a boolean when provided")
 
@@ -45,6 +58,23 @@ class DataportalMetadata:
             raise ValidationError("groups must be a list")
         for group in self.groups:
             _ = _required_string(group, "group")
+
+        if self.publisher is not None:
+            _ = _schema_mapping(
+                self.publisher,
+                "publisher",
+                allowed_fields=_PUBLISHER_FIELDS,
+                require_any=True,
+            )
+        if not isinstance(self.contact, list):
+            raise ValidationError("contact must be a list")
+        for contact in self.contact:
+            _ = _schema_mapping(
+                contact,
+                "contact",
+                allowed_fields=_CONTACT_FIELDS,
+                require_any=True,
+            )
 
         if not isinstance(self.extras, dict):
             raise ValidationError("extras must be a dict")
@@ -92,6 +122,28 @@ class DataportalMetadata:
             payload["issued"] = self.metadata.publication_date.isoformat()
         if self.metadata.language is not None:
             payload["language"] = [self.metadata.language]
+        if self.publisher is not None:
+            payload["publisher"] = [
+                _schema_mapping(
+                    self.publisher,
+                    "publisher",
+                    allowed_fields=_PUBLISHER_FIELDS,
+                    require_any=True,
+                )
+            ]
+        if self.contact:
+            payload["contact"] = [
+                _schema_mapping(
+                    item,
+                    "contact",
+                    allowed_fields=_CONTACT_FIELDS,
+                    require_any=True,
+                )
+                for item in self.contact
+            ]
+        if self.modified is not None:
+            payload["modified"] = _date_string(self.modified, "modified")
+        _add_if_present(payload, "identifier", self.identifier or self.metadata.doi)
 
         if self.groups:
             payload["groups"] = [
@@ -169,8 +221,22 @@ def _dataportal_agent(person: Person) -> dict[str, str]:
         "name": _person_name(person),
         "type": "Person",
     }
-    _add_if_present(data, "identifier", person.orcid)
+    _add_if_present(data, "identifier", _orcid_uri(person.orcid))
     return data
+
+
+def _orcid_uri(value: str | None) -> str | None:
+    """Return an ORCID as a stable HTTPS URI when present."""
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    prefix = "https://orcid.org/"
+    for scheme_prefix in ("https://orcid.org/", "http://orcid.org/"):
+        if text.startswith(scheme_prefix):
+            return prefix + text.removeprefix(scheme_prefix)
+    return prefix + text
 
 
 def _person_name(person: Person) -> str:
@@ -214,6 +280,45 @@ def _related_identifier_dict(
 
 def _json_value(value: object) -> str:
     return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+
+
+def _schema_mapping(
+    value: Mapping[str, str],
+    field_name: str,
+    *,
+    allowed_fields: frozenset[str],
+    require_any: bool,
+) -> dict[str, str]:
+    """Validate and trim a Dataportal schema mapping."""
+    if not isinstance(value, Mapping):
+        raise ValidationError(f"{field_name} must be a mapping")
+
+    data: dict[str, str] = {}
+    for key, raw_value in value.items():
+        normalized_key = _required_string(key, f"{field_name} key")
+        if normalized_key not in allowed_fields:
+            raise ValidationError(
+                f"{field_name} contains unsupported field: {normalized_key}"
+            )
+        if not isinstance(raw_value, str):
+            raise ValidationError(f"{field_name} values must be strings")
+        _add_if_present(data, normalized_key, raw_value)
+
+    if require_any and not data:
+        raise ValidationError(f"{field_name} must contain at least one non-empty field")
+    return data
+
+
+def _date_string(value: date | str, field_name: str) -> str:
+    """Validate a date-like Dataportal field and return its ISO date string."""
+    if isinstance(value, date):
+        return value.isoformat()
+    text = _required_string(value, field_name)
+    try:
+        _ = date.fromisoformat(text)
+    except ValueError as exc:
+        raise ValidationError(f"{field_name} must be an ISO date") from exc
+    return text
 
 
 def _slugify(value: str) -> str:

--- a/courier/services/dataportal/metadata.py
+++ b/courier/services/dataportal/metadata.py
@@ -7,7 +7,7 @@ import re
 import unicodedata
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from typing import Any
 
 from courier.exceptions import ValidationError
@@ -311,6 +311,8 @@ def _schema_mapping(
 
 def _date_string(value: date | str, field_name: str) -> str:
     """Validate a date-like Dataportal field and return its ISO date string."""
+    if isinstance(value, datetime):
+        raise ValidationError(f"{field_name} must be an ISO date")
     if isinstance(value, date):
         return value.isoformat()
     text = _required_string(value, field_name)

--- a/tests/unit/services/dataportal/test_metadata.py
+++ b/tests/unit/services/dataportal/test_metadata.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from datetime import datetime
 from typing import Any, cast
 
 from courier.exceptions import ValidationError
@@ -226,6 +227,13 @@ class TestDataportalMetadata(unittest.TestCase):
         )
 
         self.assertEqual(metadata.to_payload()["modified"], "2026-06-08")
+
+    def test_modified_rejects_datetime_instances(self):
+        with self.assertRaisesRegex(ValidationError, "modified must be an ISO date"):
+            DataportalMetadata(
+                metadata=publication_metadata(),
+                modified=datetime(2026, 7, 22, 10, 30),
+            )
 
     def test_schema_creator_accepts_explicit_person_name(self):
         publication = publication_metadata(

--- a/tests/unit/services/dataportal/test_metadata.py
+++ b/tests/unit/services/dataportal/test_metadata.py
@@ -10,7 +10,7 @@ from courier.metadata import (
     RelatedIdentifier,
 )
 from courier.services.dataportal import DataportalMetadata
-from courier.services.dataportal.metadata import _person_name
+from courier.services.dataportal.metadata import _orcid_uri, _person_name
 
 
 def publication_metadata(**overrides: Any) -> PublicationMetadata:
@@ -86,7 +86,7 @@ class TestDataportalMetadata(unittest.TestCase):
             payload["creator"],
             [
                 {
-                    "identifier": "0000-0000-0000-0000",
+                    "identifier": "https://orcid.org/0000-0000-0000-0000",
                     "name": "Doe, Jane",
                     "type": "Person",
                 }
@@ -94,6 +94,7 @@ class TestDataportalMetadata(unittest.TestCase):
         )
         self.assertEqual(payload["issued"], "2026-06-08")
         self.assertEqual(payload["language"], ["eng"])
+        self.assertEqual(payload["identifier"], "10.1234/example")
 
         extras = extras_by_key(payload)
         self.assertEqual(extras["pmd_profile"], "dataset-v1")
@@ -159,7 +160,7 @@ class TestDataportalMetadata(unittest.TestCase):
             payload["creator"],
             [
                 {
-                    "identifier": "0000-0000-0000-0000",
+                    "identifier": "https://orcid.org/0000-0000-0000-0000",
                     "name": "Doe, Jane",
                     "type": "Person",
                 }
@@ -169,7 +170,62 @@ class TestDataportalMetadata(unittest.TestCase):
         self.assertNotIn("version", payload)
         self.assertNotIn("issued", payload)
         self.assertNotIn("language", payload)
+        self.assertNotIn("identifier", payload)
         self.assertEqual(set(extras), {"creators"})
+
+    def test_dataportal_specific_schema_fields_are_serialized(self):
+        metadata = DataportalMetadata(
+            metadata=publication_metadata(),
+            publisher={
+                "name": "MPI-SusMat",
+                "type": "Organization",
+                "identifier": "https://ror.org/03y34c780",
+                "url": "https://www.mpie.de/",
+            },
+            contact=[
+                {
+                    "name": "Data Steward",
+                    "email": "data@example.org",
+                    "identifier": "https://ror.org/03y34c780",
+                }
+            ],
+            modified="2026-07-22",
+            identifier="https://doi.org/10.1234/explicit",
+        )
+
+        payload = metadata.to_payload()
+
+        self.assertEqual(
+            payload["publisher"],
+            [
+                {
+                    "name": "MPI-SusMat",
+                    "type": "Organization",
+                    "identifier": "https://ror.org/03y34c780",
+                    "url": "https://www.mpie.de/",
+                }
+            ],
+        )
+        self.assertEqual(
+            payload["contact"],
+            [
+                {
+                    "name": "Data Steward",
+                    "email": "data@example.org",
+                    "identifier": "https://ror.org/03y34c780",
+                }
+            ],
+        )
+        self.assertEqual(payload["modified"], "2026-07-22")
+        self.assertEqual(payload["identifier"], "https://doi.org/10.1234/explicit")
+
+    def test_modified_accepts_date_instances(self):
+        metadata = DataportalMetadata(
+            metadata=publication_metadata(),
+            modified=publication_metadata().publication_date,
+        )
+
+        self.assertEqual(metadata.to_payload()["modified"], "2026-06-08")
 
     def test_schema_creator_accepts_explicit_person_name(self):
         publication = publication_metadata(
@@ -188,11 +244,39 @@ class TestDataportalMetadata(unittest.TestCase):
             ],
         )
 
+    def test_schema_creator_keeps_multiple_creators(self):
+        publication = publication_metadata(
+            creators=[
+                Person(name="Steel Research Group"),
+                Person(name="Doe, Jane", orcid="https://orcid.org/0000-0000-0000-0001"),
+            ],
+        )
+
+        payload = DataportalMetadata(metadata=publication).to_payload()
+
+        self.assertEqual(
+            payload["creator"],
+            [
+                {
+                    "name": "Steel Research Group",
+                    "type": "Person",
+                },
+                {
+                    "identifier": "https://orcid.org/0000-0000-0000-0001",
+                    "name": "Doe, Jane",
+                    "type": "Person",
+                },
+            ],
+        )
+
     def test_person_name_rejects_invalid_person_state(self):
         person = object.__new__(Person)
 
         with self.assertRaisesRegex(ValidationError, "person requires"):
             _ = _person_name(person)
+
+    def test_orcid_uri_omits_blank_values(self):
+        self.assertIsNone(_orcid_uri(" "))
 
     def test_generated_extra_collision_is_rejected(self):
         with self.assertRaisesRegex(ValidationError, "publication_date"):
@@ -216,7 +300,11 @@ class TestDataportalMetadata(unittest.TestCase):
             ({"name": " "}, "name"),
             ({"owner_org": " "}, "owner_org"),
             ({"dataset_type": " "}, "dataset_type"),
+            ({"identifier": " "}, "identifier"),
+            ({"modified": " "}, "modified"),
             ({"groups": [" "]}, "group"),
+            ({"publisher": {"name": " "}}, "publisher"),
+            ({"contact": [{"email": " "}]}, "contact"),
             ({"extras": {" ": "value"}}, "extra key"),
         ]
 
@@ -238,6 +326,8 @@ class TestDataportalMetadata(unittest.TestCase):
         cases = [
             ({"groups": None}, "groups must be a list"),
             ({"groups": "foo"}, "groups must be a list"),
+            ({"contact": None}, "contact must be a list"),
+            ({"contact": "foo"}, "contact must be a list"),
             ({"extras": None}, "extras must be a dict"),
             ({"extras": []}, "extras must be a dict"),
         ]
@@ -258,6 +348,26 @@ class TestDataportalMetadata(unittest.TestCase):
                 metadata=publication_metadata(),
                 extras=cast(Any, {"priority": 1}),
             )
+
+    def test_schema_mappings_reject_invalid_fields_and_values(self):
+        cases = [
+            ({"publisher": "publisher"}, "publisher must be a mapping"),
+            ({"publisher": {"unknown": "value"}}, "unsupported field"),
+            ({"publisher": {"name": 1}}, "publisher values must be strings"),
+            ({"contact": [{"type": "Person"}]}, "unsupported field"),
+            ({"contact": [{"name": 1}]}, "contact values must be strings"),
+            ({"modified": "2026/07/22"}, "modified must be an ISO date"),
+        ]
+
+        for kwargs, message in cases:
+            with (
+                self.subTest(kwargs=kwargs),
+                self.assertRaisesRegex(ValidationError, message),
+            ):
+                DataportalMetadata(
+                    metadata=publication_metadata(),
+                    **cast(Any, kwargs),
+                )
 
     def test_metadata_must_be_publication_metadata(self):
         with self.assertRaisesRegex(ValidationError, "PublicationMetadata"):

--- a/tests/unit/services/dataportal/test_metadata_boundary.py
+++ b/tests/unit/services/dataportal/test_metadata_boundary.py
@@ -29,6 +29,10 @@ class TestDataportalMetadataBoundary(unittest.TestCase):
                 "groups",
                 "extras",
                 "dataset_type",
+                "publisher",
+                "contact",
+                "modified",
+                "identifier",
             },
         )
 


### PR DESCRIPTION
## Summary

Extend `DataportalMetadata` with explicit Dataportal/DCAT schema-backed metadata fields for publisher, contact point, modification date, and dataset identifier.

This builds on the conservative schema mapping from the previous PR by making Dataportal-specific fields opt-in and explicit instead of deriving them from service-neutral `PublicationMetadata`.

## Applied Changes

- Added `publisher` support as a Dataportal schema agent mapping
- Added `contact` support as a list of Dataportal contact-point mappings
- Added `modified` support with ISO date validation
- Added `identifier` support with explicit override behavior
- Use `PublicationMetadata.doi` as the schema-backed `identifier` when no explicit identifier is provided- Normalize creator ORCIDs to `https://orcid.org/...`
- Preserve multiple creators in the schema-backed `creator` payload
- Added validation for unsupported schema fields, blank mappings, invalid dates, and non-string mapping values
- Updated metadata boundary tests for the expanded Dataportal adapter API

## Example

```python
metadata = DataportalMetadata(
    metadata=publication,
    publisher={
        "name": "MPI-SusMat",
        "type": "Organization",
        "identifier": "https://ror.org/03y34c780",
        "url": "https://www.mpie.de/",
    },
    contact=[
        {
            "name": "Data Steward",
            "email": "data@example.org",
            "identifier": "https://ror.org/03y34c780",
        }
    ],
    modified="2026-07-22",
    identifier="https://doi.org/10.1234/example",
)
```

This produces schema-backed Dataportal fields such as:

```python
{
    "publisher": [
        {
            "name": "MPI-SusMat",
            "type": "Organization",
            "identifier": "https://ror.org/03y34c780",
            "url": "https://www.mpie.de/",
        }
    ],
    "contact": [
        {
            "name": "Data Steward",
            "email": "data@example.org",
            "identifier": "https://ror.org/03y34c780",
        }
    ],
    "modified": "2026-07-22",
    "identifier": "https://doi.org/10.1234/example",
}
```

## Validation

- `black`
- `ruff check`
- `pytest`
- `coverage`
- `mypy`