### PR TITLE
Update CI workflows to use Codecov and `pyiron/actions@actions-4.2.1`

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.1.0
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.2.1
     secrets: inherit
     with:
       do-coveralls: false

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,3 +10,6 @@ jobs:
   codeql:
     uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.1.0
     secrets: inherit
+    with:
+      do-coveralls: false
+      do-codecov: true

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-4.1.0
+    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-4.2.1
     secrets: inherit

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-4.1.0
+    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-4.2.1
     secrets: inherit

--- a/.github/workflows/pr-target-opened.yml
+++ b/.github/workflows/pr-target-opened.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-4.1.0
+    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-4.2.1
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.2.0
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.2.1
     secrets: inherit
     with:
       do-coveralls: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   hatch-release:
-    uses: pyiron/actions/.github/workflows/hatch-release.yml@actions-4.1.0
+    uses: pyiron/actions/.github/workflows/hatch-release.yml@actions-4.2.1
     secrets: inherit
     with:
       semantic-upper-bound: 'minor'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.1.0
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.2.1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Configure the daily coverage workflow to upload to Codecov and disable Coveralls.
- Pin all reusable `pyiron/actions` workflow references to `actions-4.2.1`.
- Preserve existing workflow triggers, inputs, and release behavior.

## Validation
Parsed workflow YAML, ran `actionlint`, and checked the diff for whitespace errors.